### PR TITLE
Jenkinsfile.integration: Add basic jenkins run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ env/
 venv/
 ENV/
 my.env
+*.env
 
 # Spyder project settings
 .spyderproject

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -33,6 +33,7 @@ pipeline {
         ROOKCHECK_OS_EXTERNAL_NETWORK = "${params.OS_EXTERNAL_NETWORK}"
         ROOKCHECK_OS_FLAVOR = "${params.OS_FLAVOR}"
         ROOKCHECK_OS_IMAGE = "${params.OS_IMAGE}"
+        ROOKCHECK_BUILD_ROOK_FROM_GIT = "FALSE"
     }
     stages {
         stage('test basic') {

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -1,0 +1,40 @@
+#!groovy
+
+
+def compute_node='storage-rookcheck'
+// the prefix we want to use for the rookcheck environment
+def cluster_prefix="${currentBuild.fullProjectName.replace('/', '_')}-${currentBuild.number}_"
+
+pipeline {
+    agent {
+        label "${compute_node}"
+    }
+
+    options {
+    parallelsAlwaysFailFast()
+    }
+
+    parameters {
+        /* first value in the list is the default */
+        choice(name: 'OS_CLOUD', choices: ['ecp'], description: 'OpenStack Cloud to use')
+        string(name: 'OS_EXTERNAL_NETWORK', defaultValue: 'floating', description: 'the OpenStack external network')
+        string(name: 'OS_FLAVOR', defaultValue: 'm1.medium', description: 'the OpenStack image flavor')
+        string(name: 'OS_IMAGE', defaultValue: 'openSUSE-Leap-15.1-JeOS.x86_64-OpenStack-Cloud', description: 'the OpenStack image name/id')
+    }
+
+    environment {
+        ROOKCHECK_CLUSTER_PREFIX = "${cluster_prefix}"
+        OS_CLOUD = "${params.OS_CLOUD}"
+        ROOKCHECK_OS_EXTERNAL_NETWORK = "${params.OS_EXTERNAL_NETWORK}"
+        ROOKCHECK_OS_FLAVOR = "${params.OS_FLAVOR}"
+        ROOKCHECK_OS_IMAGE = "${params.OS_IMAGE}"
+    }
+    stages {
+        stage('test basic') {
+            steps {
+        sh "env"
+                sh "tox -epy3 tests/test_basic.py"
+            }
+        }
+    }
+}

--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -23,7 +23,12 @@ pipeline {
     }
 
     environment {
-        ROOKCHECK_CLUSTER_PREFIX = "${cluster_prefix}"
+        // ROOKCHECK_CLUSTER_PREFIX = "${cluster_prefix}"
+        // FIXME(jhesketh): ${cluster_prefix} is too long for a node name.
+        //                  kubectl annotate fails when the network isn't set
+        //                  up and the name is long. This is possibly an
+        //                  upstream kubernetes bug that I need to investigate.
+        ROOKCHECK_CLUSTER_PREFIX = "rookcheck-jen"
         OS_CLOUD = "${params.OS_CLOUD}"
         ROOKCHECK_OS_EXTERNAL_NETWORK = "${params.OS_EXTERNAL_NETWORK}"
         ROOKCHECK_OS_FLAVOR = "${params.OS_FLAVOR}"

--- a/config/rook_upstream.toml
+++ b/config/rook_upstream.toml
@@ -1,0 +1,5 @@
+[default]
+
+# Whether or not to build rook from git. If not, the upstream dockerhub images
+# are used.
+build_rook_from_git = true

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -41,4 +41,4 @@ _use_free_strategy = false
 _remove_workspace = true
 
 # You will only need to edit the config relating to your hardware provider
-dynaconf_include = ["libvirt.toml", "openstack.toml"]
+dynaconf_include = ["libvirt.toml", "openstack.toml", "rook_upstream.toml"]


### PR DESCRIPTION
This will add a Jenkins.integration file which is a Jenkins
pipeline. That file can be used to test PRs against rookcheck.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>