### PR TITLE
tests/lib/hardware: Mark more methods as private

### DIFF
--- a/tests/lib/hardware/hardware_base.py
+++ b/tests/lib/hardware/hardware_base.py
@@ -80,6 +80,10 @@ class HardwareBase(ABC):
         self.pubkey = "%s %s" % (key.get_name(), key.get_base64())
 
     @abstractmethod
+    def destroy(self):
+        pass
+
+    @abstractmethod
     def get_connection(self):
         pass
 
@@ -100,3 +104,9 @@ class HardwareBase(ABC):
             self._ansible_runner_nodes = self.nodes.copy()
 
         return self._ansible_runner.run_play(play_source)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.destroy()

--- a/tests/lib/hardware/openstack_libcloud.py
+++ b/tests/lib/hardware/openstack_libcloud.py
@@ -420,9 +420,3 @@ class Hardware(HardwareBase):
         if r.host_failed or r.host_unreachable:
             # TODO(jhesketh): Provide some more useful feedback and/or checking
             raise Exception("One or more hosts failed")
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type, value, traceback):
-        self.destroy()


### PR DESCRIPTION
The methods are only internally used and should not be used outside.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>