### PR TITLE
Automatically output Ansible result dictionary on failure

### DIFF
--- a/tests/lib/hardware/openstack_libcloud.py
+++ b/tests/lib/hardware/openstack_libcloud.py
@@ -365,14 +365,5 @@ class Hardware(HardwareBase):
         d = get_distro()()
 
         self.remove_host_keys()
-        r = self.execute_ansible_play(d.wait_for_connection_play())
-
-        if r.host_failed or r.host_unreachable:
-            # TODO(jhesketh): Provide some more useful feedback and/or checking
-            raise Exception("One or more hosts failed")
-
-        r = self.execute_ansible_play(d.bootstrap_play())
-
-        if r.host_failed or r.host_unreachable:
-            # TODO(jhesketh): Provide some more useful feedback and/or checking
-            raise Exception("One or more hosts failed")
+        self.execute_ansible_play(d.wait_for_connection_play())
+        self.execute_ansible_play(d.bootstrap_play())

--- a/tests/lib/kubernetes/vanilla.py
+++ b/tests/lib/kubernetes/vanilla.py
@@ -36,49 +36,21 @@ class Vanilla(KubernetesBase):
         super().__init__(hardware)
 
     def install_kubernetes(self):
-        r = self.hardware.execute_ansible_play(self.distro.copy_needed_files())
-
-        if r.host_failed or r.host_unreachable:
-            # TODO(jhesketh): Provide some more useful feedback and/or checking
-            raise Exception("One or more hosts failed")
-
-        r = self.hardware.execute_ansible_play(
-            self.distro.install_kubeadm_play())
-
-        if r.host_failed or r.host_unreachable:
-            # TODO(jhesketh): Provide some more useful feedback and/or checking
-            raise Exception("One or more hosts failed")
-
-        r = self.hardware.execute_ansible_play(
+        self.hardware.execute_ansible_play(self.distro.copy_needed_files())
+        self.hardware.execute_ansible_play(self.distro.install_kubeadm_play())
+        self.hardware.execute_ansible_play(
             self.distro.copy_needed_files_master())
 
-        if r.host_failed or r.host_unreachable:
-            # TODO(jhesketh): Provide some more useful feedback and/or checking
-            raise Exception("One or more hosts failed")
-
         r = self.hardware.execute_ansible_play(self.distro.setup_master_play())
-
-        if r.host_failed or r.host_unreachable:
-            # TODO(jhesketh): Provide some more useful feedback and/or checking
-            raise Exception("One or more hosts failed")
-
         # TODO(jhesketh): Figure out a better way to get ansible output/results
         join_command = \
             r.host_ok[list(r.host_ok.keys())[0]][-1]._result['stdout']
 
-        r = self.hardware.execute_ansible_play(
+        self.hardware.execute_ansible_play(
             self.distro.join_workers_to_master(join_command))
 
-        if r.host_failed or r.host_unreachable:
-            # TODO(jhesketh): Provide some more useful feedback and/or checking
-            raise Exception("One or more hosts failed")
-
-        r = self.hardware.execute_ansible_play(
+        self.hardware.execute_ansible_play(
             self.distro.fetch_kubeconfig(self.hardware.working_dir))
-
-        if r.host_failed or r.host_unreachable:
-            # TODO(jhesketh): Provide some more useful feedback and/or checking
-            raise Exception("One or more hosts failed")
 
         self._configure_kubernetes_client()
         self._download_kubectl()

--- a/tests/lib/rook.py
+++ b/tests/lib/rook.py
@@ -167,12 +167,8 @@ class RookCluster():
     def upload_rook_image(self):
         d = UploadRook()
 
-        r = self.kubernetes.hardware.execute_ansible_play(
+        self.kubernetes.hardware.execute_ansible_play(
             d.upload_image_play(self.builddir))
-
-        if r.host_failed or r.host_unreachable:
-            # TODO(jhesketh): Provide some more useful feedback and/or checking
-            raise Exception("One or more hosts failed")
 
     def install_rook(self):
         if not self._rook_built:


### PR DESCRIPTION
Provide more detail in logging for when Ansible fails (or a node is
unreachable). Also returns the successful nodes in a run for extra
information.

This reduces the duplication of error catching for running playbooks.