### PR TITLE
Use absolute path for raw ansible playbooks

### DIFF
--- a/tests/lib/ansible_helper.py
+++ b/tests/lib/ansible_helper.py
@@ -152,7 +152,9 @@ class AnsibleRunner(object):
         return inventory_dir
 
     def run_play_raw(self, playbook):
-        path = os.path.join('tests/assets/ansible', playbook)
+        path = os.path.abspath(os.path.join(
+            os.path.dirname(__file__), 'assets/ansible', playbook
+        ))
         logger.info(f'Running playbook {path}')
         try:
             subprocess.run(['ansible-playbook', '-i', self.inventory_dir,


### PR DESCRIPTION
In case somebody runs tox from an unexpected dir.