### PR TITLE
kubernetes/caasp: Fix kubectl path

### DIFF
--- a/tests/lib/kubernetes/caasp.py
+++ b/tests/lib/kubernetes/caasp.py
@@ -35,6 +35,11 @@ class CaaSP(KubernetesBase):
         self._clusterpath = os.path.join(self.workspace.working_dir, 'cluster')
         self._kubeconfig = os.path.join(self.workspace.working_dir,
                                         'admin.conf')
+        # FIXME(toabctl): The CaaSP implementation is not downloading the
+        # 'kubectl' executable so it's not available in the workspace dir.
+        # We currently just assume that on the local machine, 'kubectl'
+        # is available
+        self._kubectl_exec = 'kubectl'
 
     def destroy(self, skip=False):
         logger.info(f"kube destroy on hardware {self.hardware}")

--- a/tests/lib/kubernetes/caasp.py
+++ b/tests/lib/kubernetes/caasp.py
@@ -33,7 +33,7 @@ class CaaSP(KubernetesBase):
     def __init__(self, workspace: Workspace, hardware: HardwareBase):
         super().__init__(workspace, hardware)
         self._clusterpath = os.path.join(self.workspace.working_dir, 'cluster')
-        self._kubeconfig = os.path.join(self.workspace.working_dir,
+        self._kubeconfig = os.path.join(self.workspace.working_dir, 'cluster',
                                         'admin.conf')
         # FIXME(toabctl): The CaaSP implementation is not downloading the
         # 'kubectl' executable so it's not available in the workspace dir.


### PR DESCRIPTION
When using CaaSP as k8s deployment mechanism, the kubectl binary is
not downloaded. Instead we assume that the binary is available on the
local machine. So use the correct path (instead of something in the
workspace dir).

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>