### PR TITLE
Add more structure rook code

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,6 @@ import pytest
 import threading
 
 from tests import config
-from tests.lib.rook import RookCluster
 from tests.lib.workspace import Workspace
 
 
@@ -31,8 +30,10 @@ else:
 
 if config.DISTRO == 'SLES_CaaSP':
     from tests.lib.kubernetes.caasp import CaaSP as Kubernetes
+    from tests.lib.rook.ses import RookCluster as RookCluster
 else:
     from tests.lib.kubernetes.vanilla import Vanilla as Kubernetes  # type: ignore  # noqa: E501
+    from tests.lib.rook.upstream import RookCluster as RookCluster
 
 logger = logging.getLogger(__name__)
 

--- a/tests/lib/rook/base.py
+++ b/tests/lib/rook/base.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2019 SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from abc import ABC
+
+logger = logging.getLogger(__name__)
+
+
+class RookBase(ABC):
+    def __init__(self, workspace, kubernetes):
+        self._workspace = workspace
+        self.kubernetes = kubernetes
+        self.toolbox_pod = None
+        self.ceph_dir = None
+        logger.info(f"rook init on {self.kubernetes.hardware}")
+
+    @property
+    def workspace(self):
+        return self._workspace
+
+    def destroy(self, skip=True):
+        logger.info(f"rook destroy on {self.kubernetes.hardware}")
+        if skip:
+            # We can skip in most cases since the kubernetes cluster, if not
+            # the nodes themselves will be destroyed instead.
+            return
+        # TODO(jhesketh): Uninstall rook
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.destroy()

--- a/tests/lib/rook/upstream.py
+++ b/tests/lib/rook/upstream.py
@@ -21,84 +21,17 @@ import wget
 
 from tests import config
 from tests.lib import common
-
+from tests.lib.rook.base import RookBase
 
 logger = logging.getLogger(__name__)
 
 
-class UploadRook():
-    def upload_image_play(self, buildpath):
-        tasks = []
-
-        tasks.append(
-            dict(
-                name="Copy Rook Ceph image to cluster nodes",
-                action=dict(
-                    module='copy',
-                    args=dict(
-                        src=os.path.join(buildpath, "rook-ceph.tar.gz"),
-                        dest="/root/.images/"
-                    )
-                )
-            )
-        )
-
-        # TODO(jhesketh): build arch may differ
-        tasks.append(
-            dict(
-                name="Load rook ceph image",
-                action=dict(
-                    module='shell',
-                    args=dict(
-                        cmd='docker load '
-                            '--input /root/.images/rook-ceph.tar.gz'
-                    )
-                )
-            )
-        )
-
-        play_source = dict(
-            name="Upload rook image",
-            hosts="all",
-            tasks=tasks,
-            gather_facts="no",
-            # Temporary workaround for mitogen failing to copy files or
-            # templates.
-            strategy="free" if config._USE_FREE_STRATEGY else "linear",
-        )
-        return play_source
-
-
-class RookCluster():
+class RookCluster(RookBase):
     def __init__(self, workspace, kubernetes):
-        self._workspace = workspace
-        self.kubernetes = kubernetes
-        self.toolbox_pod = None
-        self.ceph_dir = None
+        super().__init__(workspace, kubernetes)
         self._rook_built = False
         self.builddir = os.path.join(self.workspace.working_dir, 'rook_build')
         os.mkdir(self.builddir)
-
-        logger.info(f"rook init on {self.kubernetes.hardware}")
-
-    @property
-    def workspace(self):
-        return self._workspace
-
-    def destroy(self, skip=True):
-        logger.info(f"rook destroy on {self.kubernetes.hardware}")
-        if skip:
-            # We can skip in most cases since the kubernetes cluster, if not
-            # the nodes themselves will be destroyed instead.
-            return
-        # TODO(jhesketh): Uninstall rook
-        pass
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type, value, traceback):
-        self.destroy()
 
     def build_rook(self):
         def _execute(command):
@@ -233,3 +166,46 @@ class RookCluster():
                 "rook-ceph-tools")
 
         return self.kubernetes.execute_in_pod(command, self.toolbox_pod)
+
+
+class UploadRook():
+    def upload_image_play(self, buildpath):
+        tasks = []
+
+        tasks.append(
+            dict(
+                name="Copy Rook Ceph image to cluster nodes",
+                action=dict(
+                    module='copy',
+                    args=dict(
+                        src=os.path.join(buildpath, "rook-ceph.tar.gz"),
+                        dest="/root/.images/"
+                    )
+                )
+            )
+        )
+
+        # TODO(jhesketh): build arch may differ
+        tasks.append(
+            dict(
+                name="Load rook ceph image",
+                action=dict(
+                    module='shell',
+                    args=dict(
+                        cmd='docker load '
+                            '--input /root/.images/rook-ceph.tar.gz'
+                    )
+                )
+            )
+        )
+
+        play_source = dict(
+            name="Upload rook image",
+            hosts="all",
+            tasks=tasks,
+            gather_facts="no",
+            # Temporary workaround for mitogen failing to copy files or
+            # templates.
+            strategy="free" if config._USE_FREE_STRATEGY else "linear",
+        )
+        return play_source


### PR DESCRIPTION
This PR aims to structure rook code as it was done for kubernetes
The RookBase class is inherited by various implementation of
rook (upstream, ses etc...) and imported as RookCluster