### PR TITLE
hardware/hardware_base: Add masters and workers properties

### DIFF
--- a/doc/source/development_notes.rst
+++ b/doc/source/development_notes.rst
@@ -44,6 +44,7 @@ Now we can install kubernetes:
 
     import tests.lib.kubernetes
     k = tests.lib.kubernetes.VanillaKubernetes(h)
+    k.bootstrap()
     k.install_kubernetes()
 
 You can then interact with the kubernetes cluster with (for example):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,6 +62,7 @@ def kubernetes(workspace, hardware):
     # etc), we should do them from an ABC so to ensure the interfaces are
     # correct.
     with Kubernetes(workspace, hardware) as kubernetes:
+        kubernetes.bootstrap()
         kubernetes.install_kubernetes()
         yield kubernetes
 
@@ -93,6 +94,7 @@ def rook_cluster(workspace):
                 # build rook thread
                 hardware.boot_nodes()
                 hardware.prepare_nodes()
+                kubernetes.bootstrap()
                 kubernetes.install_kubernetes()
 
                 if config._USE_THREADS:

--- a/tests/lib/hardware/hardware_base.py
+++ b/tests/lib/hardware/hardware_base.py
@@ -25,7 +25,7 @@
 from abc import ABC, abstractmethod
 import logging
 import subprocess
-from typing import Dict, Any
+from typing import Dict, Any, List
 
 from tests.lib.distro import get_distro
 from tests.lib.hardware.node_base import NodeBase, NodeRole
@@ -57,6 +57,14 @@ class HardwareBase(ABC):
     @property
     def nodes(self):
         return self._nodes
+
+    @property
+    def masters(self) -> List[NodeRole]:
+        return self._get_node_by_role(NodeRole.MASTER)
+
+    @property
+    def workers(self) -> List[NodeRole]:
+        return self._get_node_by_role(NodeRole.WORKER)
 
     def _node_remove_ssh_key(self, node: NodeBase):
         # The mitogen plugin does not correctly ignore host key checking, so we
@@ -117,20 +125,12 @@ class HardwareBase(ABC):
         }
         return vars
 
-    def get_node_by_role(self, role: NodeRole):
+    def _get_node_by_role(self, role: NodeRole):
         items = []
         for node_name, node_obj in self.nodes.items():
             if node_obj._role == role:
                 items.append(node_obj)
         return items
-
-    def get_masters(self):
-        self.masters = self.get_node_by_role(NodeRole.MASTER)
-        return self.masters
-
-    def get_workers(self):
-        self.workers = self.get_node_by_role(NodeRole.WORKER)
-        return self.workers
 
     def __enter__(self):
         return self

--- a/tests/lib/kubernetes/caasp.py
+++ b/tests/lib/kubernetes/caasp.py
@@ -52,8 +52,6 @@ class CaaSP(KubernetesBase):
     def install_kubernetes(self):
         super().install_kubernetes()
         self.hardware.execute_ansible_play_raw('playbook_caasp.yaml')
-        self.hardware.get_masters()
-        self.hardware.get_workers()
         self._caasp_init()
         with self.workspace.chdir(self._clusterpath):
             self._caasp_bootstrap()

--- a/tests/lib/kubernetes/caasp.py
+++ b/tests/lib/kubernetes/caasp.py
@@ -49,12 +49,15 @@ class CaaSP(KubernetesBase):
             return
         # TODO(jhesketh): Uninstall kubernetes
 
-    def install_kubernetes(self):
-        super().install_kubernetes()
+    def bootstrap(self):
+        super().bootstrap()
         self.hardware.execute_ansible_play_raw('playbook_caasp.yaml')
         self._caasp_init()
         with self.workspace.chdir(self._clusterpath):
             self._caasp_bootstrap()
+
+    def install_kubernetes(self):
+        super().install_kubernetes()
         with self.workspace.chdir(self._clusterpath):
             self._caasp_join()
 

--- a/tests/lib/kubernetes/kubernetes_base.py
+++ b/tests/lib/kubernetes/kubernetes_base.py
@@ -44,6 +44,16 @@ class KubernetesBase(ABC):
         logger.info(f"kube init on hardware {self.hardware}")
 
     @abstractmethod
+    def bootstrap(self):
+        """
+        bootstrap a k8s cluster.
+        After calling this method, at least a single master node
+        should be available in the k8s cluster so other master or worker
+        nodes can join
+        """
+        logging.info("bootstrapping the kubernetes cluster")
+
+    @abstractmethod
     def install_kubernetes(self):
         pass
 

--- a/tests/lib/kubernetes/vanilla.py
+++ b/tests/lib/kubernetes/vanilla.py
@@ -43,12 +43,17 @@ class Vanilla(KubernetesBase):
         else:
             raise Exception("OS yet to be implemented/unsupport.")
 
-    def install_kubernetes(self):
+    def bootstrap(self):
         self.hardware.execute_ansible_play(self.distro.copy_needed_files())
         self.hardware.execute_ansible_play(self.distro.install_kubeadm_play())
         self.hardware.execute_ansible_play(
             self.distro.copy_needed_files_master())
 
+        self.hardware.execute_ansible_play(self.distro.setup_master_play())
+
+    def install_kubernetes(self):
+        # FIXME(toabctl): we call this already in bootstrap().
+        # Need to figure out how to get "r"
         r = self.hardware.execute_ansible_play(self.distro.setup_master_play())
         # TODO(jhesketh): Figure out a better way to get ansible output/results
         join_command = \
@@ -71,7 +76,7 @@ class Vanilla(KubernetesBase):
 
     def _setup_flannel(self):
         for node in self.hardware.nodes.values():
-            self.kubectl(
+            self.kubtectl(
                 "annotate node %s "
                 "flannel.alpha.coreos.com/public-ip-overwrite=%s "
                 "--overwrite" % (


### PR DESCRIPTION
Mark the method get_node_by_role() as private given that it should
only be used internally. Then also drop the get_masters() and
get_workers() functions and just add properties for master and
worker.
That's what is used in the end and in the caasp implementation, there
is no longer a need to call get_masters() and get_workers().

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>