### PR TITLE
README: Link rook, drop libcloud requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 rookcheck
 =========
 
-`rookcheck` is a testing platform for rook.io. The intention is to provide
+`rookcheck` is a testing platform for `rook.io`_. The intention is to provide
 developers with a way to simulate various environments and scenarios that may
 occur within them.
 
@@ -16,9 +16,6 @@ Because a test may need to interact with the underlying hardware the unit tests
 will set up and configure the nodes, distros, kubernetes, and rook itself.
 These are then exposed to the test writer to interact with further or to verify
 the environment.
-
-rookcheck requires VM's from `libcloud` to set up and perform the tests
-against.
 
 `Read the full documentation <https://rookcheck.readthedocs.io/>`_.
 
@@ -53,3 +50,6 @@ Run tests:
 .. image:: https://readthedocs.org/projects/rookcheck/badge/?version=latest
    :target: https://rookcheck.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
+
+
+.. _`rook.io`: https://rook.io/


### PR DESCRIPTION
Link rook.io for easier navigation. Also drop the libcloud
requirement. There are already 2 implementations (libcloud and
libvirt).

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>