### PR TITLE
Better execution and logging

### DIFF
--- a/tests/lib/common.py
+++ b/tests/lib/common.py
@@ -68,7 +68,7 @@ def wait_for_result(func, *args, matcher=simple_matcher(True), attempts=20,
     raise Exception("Timed out waiting for result")
 
 
-def execute(command: str, capture=False, check=False, disable_logger=False,
+def execute(command: str, capture=False, check=True, disable_logger=False,
             env: Optional[Dict[str, str]] = None) -> Tuple[
                 int, Optional[str], Optional[str]]:
     """A helper util to excute `command`.

--- a/tests/lib/common.py
+++ b/tests/lib/common.py
@@ -67,7 +67,8 @@ def wait_for_result(func, *args, matcher=simple_matcher(True), attempts=20,
     raise Exception("Timed out waiting for result")
 
 
-def execute(command, capture=False, check=False, disable_logger=False):
+def execute(command, capture=False, check=False, disable_logger=False,
+            env=None):
     """A helper util to excute `command`.
 
     If `disable_logger` is False, the stdout and stderr are redirected to the
@@ -80,6 +81,8 @@ def execute(command, capture=False, check=False, disable_logger=False):
     into memory, stdout and stderr are only available on the exception if
     `capture` was True.
 
+    `env` is a dictionary of environment vars passed into Popen.
+
     Returns a tuple of (rc code, output), where output is a dict with stdout
     and stderr if capture is True.
     """
@@ -89,6 +92,7 @@ def execute(command, capture=False, check=False, disable_logger=False):
         shell=True,
         stdout=outpipe, stderr=outpipe,
         universal_newlines=True,
+        env=env,
     )
 
     output = None

--- a/tests/lib/common.py
+++ b/tests/lib/common.py
@@ -88,7 +88,8 @@ def execute(command: str, capture=False, check=True, disable_logger=False,
     Returns a tuple of (rc code, stdout, stdin), where stdout and stdin are
     None if `capture` is False, or are a string.
     """
-    outpipe = None if disable_logger and not capture else subprocess.PIPE
+    outpipe = subprocess.DEVNULL \
+        if disable_logger and not capture else subprocess.PIPE
     process = subprocess.Popen(
         command,
         shell=True,

--- a/tests/lib/common.py
+++ b/tests/lib/common.py
@@ -67,11 +67,11 @@ def wait_for_result(func, *args, matcher=simple_matcher(True), attempts=20,
     raise Exception("Timed out waiting for result")
 
 
-def execute(command, capture=False, check=False):
+def execute(command, capture=False, check=False, disable_logger=False):
     """A helper util to excute `command`.
 
-    The stdout and stderr are redirected to the logging module. You can
-    optionally catpure it by setting `capture` to True.
+    If `disable_logger` is False, the stdout and stderr are redirected to the
+    logging module. You can optionally catpure it by setting `capture` to True.
     stderr is logged as a warning as it is up to the caller to raise any
     actual errors from the RC code (or to use the `check` param).
 
@@ -83,10 +83,11 @@ def execute(command, capture=False, check=False):
     Returns a tuple of (rc code, output), where output is a dict with stdout
     and stderr if capture is True.
     """
+    outpipe = None if disable_logger and not capture else subprocess.PIPE
     process = subprocess.Popen(
         command,
         shell=True,
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        stdout=outpipe, stderr=outpipe,
         universal_newlines=True,
     )
 
@@ -118,17 +119,23 @@ def execute(command, capture=False, check=False):
             elif output == '' and process.poll() is not None:
                 break
 
-    stdout_thread = threading.Thread(
-        target=read_stdout_from_process, args=(process, output))
-    stderr_thread = threading.Thread(
-        target=read_stderr_from_process, args=(process, output))
-    stdout_thread.start()
-    stderr_thread.start()
-    stdout_thread.join()
-    stderr_thread.join()
+    if not disable_logger:
+        stdout_thread = threading.Thread(
+            target=read_stdout_from_process, args=(process, output))
+        stderr_thread = threading.Thread(
+            target=read_stderr_from_process, args=(process, output))
+        stdout_thread.start()
+        stderr_thread.start()
+        stdout_thread.join()
+        stderr_thread.join()
+
+    if disable_logger and capture:
+        output['stdout'] = process.stdout.read()
+        output['stderr'] = process.stderr.read()
 
     rc = process.wait()
-    logger.info(f"Command {command} finished with RC {rc}")
+    if not disable_logger:
+        logger.info(f"Command {command} finished with RC {rc}")
 
     if check and rc != 0:
         if capture:

--- a/tests/lib/hardware/hardware_base.py
+++ b/tests/lib/hardware/hardware_base.py
@@ -24,9 +24,9 @@
 
 from abc import ABC, abstractmethod
 import logging
-import subprocess
 from typing import Dict, Any, List
 
+from tests.lib.common import execute
 from tests.lib.distro import get_distro
 from tests.lib.hardware.node_base import NodeBase, NodeRole
 
@@ -75,7 +75,7 @@ class HardwareBase(ABC):
         # be available (in order to even be able to get them).
         # Therefore simply remove any entries from your known_hosts. It's also
         # helpful to do this after a build to clean up anything locally.
-        subprocess.run(f"ssh-keygen -R {node.get_ssh_ip()}", shell=True)
+        execute(f"ssh-keygen -R {node.get_ssh_ip()}")
 
     def destroy(self):
         logger.info("Remove all nodes from Hardware")

--- a/tests/lib/hardware/hardware_base.py
+++ b/tests/lib/hardware/hardware_base.py
@@ -26,7 +26,6 @@ from abc import ABC, abstractmethod
 import logging
 from typing import Dict, Any, List
 
-from tests.lib.common import execute
 from tests.lib.distro import get_distro
 from tests.lib.hardware.node_base import NodeBase, NodeRole
 
@@ -75,7 +74,8 @@ class HardwareBase(ABC):
         # be available (in order to even be able to get them).
         # Therefore simply remove any entries from your known_hosts. It's also
         # helpful to do this after a build to clean up anything locally.
-        execute(f"ssh-keygen -R {node.get_ssh_ip()}")
+        self.workspace.execute(
+            f"ssh-keygen -R {node.get_ssh_ip()}", check=False)
 
     def destroy(self):
         logger.info("Remove all nodes from Hardware")

--- a/tests/lib/hardware/hardware_base.py
+++ b/tests/lib/hardware/hardware_base.py
@@ -74,8 +74,11 @@ class HardwareBase(ABC):
         # be available (in order to even be able to get them).
         # Therefore simply remove any entries from your known_hosts. It's also
         # helpful to do this after a build to clean up anything locally.
+        logger.info(
+            f"Removing {node.get_ssh_ip()} from known-hosts if exists.")
         self.workspace.execute(
-            f"ssh-keygen -R {node.get_ssh_ip()}", check=False)
+            f"ssh-keygen -R {node.get_ssh_ip()}", check=False,
+            disable_logger=True)
 
     def destroy(self):
         logger.info("Remove all nodes from Hardware")

--- a/tests/lib/hardware/libvirt.py
+++ b/tests/lib/hardware/libvirt.py
@@ -25,7 +25,6 @@
 import netaddr
 import os
 import shutil
-import subprocess
 import time
 import tempfile
 import textwrap
@@ -40,6 +39,7 @@ import socket
 from typing import List
 from xml.dom import minidom
 
+from tests.lib.common import execute
 from tests.lib.hardware.hardware_base import HardwareBase
 from tests.lib.hardware.node_base import NodeBase, NodeRole
 from tests.lib.workspace import Workspace
@@ -135,10 +135,9 @@ class Node(NodeBase):
             logger.info(f"node {self.name}: Delete available backing image "
                         f"{self._snap_img_path}")
             os.remove(self._snap_img_path)
-        subprocess.check_call(f"qemu-img create -f qcow2 -F qcow2 -o "
-                              f"backing_file={self._image_path} "
-                              f"{self._snap_img_path} 10G",
-                              shell=True)
+        execute(f"qemu-img create -f qcow2 -F qcow2 -o "
+                f"backing_file={self._image_path} {self._snap_img_path} 10G",
+                check=True)
         logger.info(f"node {self.name}: created qcow2 backing file under"
                     f"{self._snap_img_path}")
 
@@ -172,8 +171,7 @@ class Node(NodeBase):
                     '-volid', 'cidata',
                     '-joliet', '-rock',
                     tempdir]
-            subprocess.check_call(args, stdout=subprocess.DEVNULL,
-                                  stderr=subprocess.DEVNULL)
+            execute(" ".join(args), check=True, disable_logger=True)
 
     def _get_domain(self, domain_name, image, cloud_init_seed, network_name,
                     memory):

--- a/tests/lib/hardware/libvirt.py
+++ b/tests/lib/hardware/libvirt.py
@@ -259,14 +259,16 @@ class Hardware(HardwareBase):
     def _get_image_path(self):
         if (config.PROVIDER_LIBVIRT_IMAGE.startswith("http://") or
                 config.PROVIDER_LIBVIRT_IMAGE.startswith("https://")):
-            logging.debug("Downloading image from URL")
+            logging.debug(
+                f"Downloading image from {config.PROVIDER_LIBVIRT_IMAGE}")
             download_location = os.path.join(
                 self.workspace.working_dir,
                 os.path.basename(config.PROVIDER_LIBVIRT_IMAGE)
             )
             wget.download(
                 config.PROVIDER_LIBVIRT_IMAGE,
-                download_location
+                download_location,
+                bar=None
             )
             return download_location
         return config.PROVIDER_LIBVIRT_IMAGE

--- a/tests/lib/hardware/libvirt.py
+++ b/tests/lib/hardware/libvirt.py
@@ -136,8 +136,7 @@ class Node(NodeBase):
                         f"{self._snap_img_path}")
             os.remove(self._snap_img_path)
         execute(f"qemu-img create -f qcow2 -F qcow2 -o "
-                f"backing_file={self._image_path} {self._snap_img_path} 10G",
-                check=True)
+                f"backing_file={self._image_path} {self._snap_img_path} 10G")
         logger.info(f"node {self.name}: created qcow2 backing file under"
                     f"{self._snap_img_path}")
 
@@ -171,7 +170,7 @@ class Node(NodeBase):
                     '-volid', 'cidata',
                     '-joliet', '-rock',
                     tempdir]
-            execute(" ".join(args), check=True, disable_logger=True)
+            execute(" ".join(args), disable_logger=True)
 
     def _get_domain(self, domain_name, image, cloud_init_seed, network_name,
                     memory):

--- a/tests/lib/hardware/openstack_libcloud.py
+++ b/tests/lib/hardware/openstack_libcloud.py
@@ -388,7 +388,10 @@ class Hardware(HardwareBase):
             self.remove_ssh_key(node.get_ssh_ip())
 
     def remove_ssh_key(self, ip):
-        self.workspace.execute(f"ssh-keygen -R {ip}", check=False)
+        logger.info(
+            f"Removing {ip} from known-hosts if exists.")
+        self.workspace.execute(
+            f"ssh-keygen -R {ip}", check=False, disable_logger=True)
 
     def __enter__(self):
         return self

--- a/tests/lib/hardware/openstack_libcloud.py
+++ b/tests/lib/hardware/openstack_libcloud.py
@@ -36,7 +36,6 @@ from libcloud.compute.types import Provider, NodeState, StorageVolumeState
 from libcloud.compute.providers import get_driver
 from urllib.parse import urlparse
 
-from tests.lib.common import execute
 from tests.lib.hardware.hardware_base import HardwareBase
 from tests.lib.hardware.node_base import NodeBase, NodeRole
 from tests.lib.workspace import Workspace
@@ -389,7 +388,7 @@ class Hardware(HardwareBase):
             self.remove_ssh_key(node.get_ssh_ip())
 
     def remove_ssh_key(self, ip):
-        execute(f"ssh-keygen -R {ip}")
+        self.workspace.execute(f"ssh-keygen -R {ip}", check=False)
 
     def __enter__(self):
         return self

--- a/tests/lib/hardware/openstack_libcloud.py
+++ b/tests/lib/hardware/openstack_libcloud.py
@@ -26,7 +26,6 @@ import logging
 import threading
 import time
 from typing import Dict, List
-import subprocess
 
 import libcloud.security
 from libcloud.compute.base import NodeImage
@@ -37,6 +36,7 @@ from libcloud.compute.types import Provider, NodeState, StorageVolumeState
 from libcloud.compute.providers import get_driver
 from urllib.parse import urlparse
 
+from tests.lib.common import execute
 from tests.lib.hardware.hardware_base import HardwareBase
 from tests.lib.hardware.node_base import NodeBase, NodeRole
 from tests.lib.workspace import Workspace
@@ -389,10 +389,7 @@ class Hardware(HardwareBase):
             self.remove_ssh_key(node.get_ssh_ip())
 
     def remove_ssh_key(self, ip):
-        subprocess.run(
-            "ssh-keygen -R %s" % ip,
-            shell=True
-        )
+        execute(f"ssh-keygen -R {ip}")
 
     def __enter__(self):
         return self

--- a/tests/lib/kubernetes/caasp.py
+++ b/tests/lib/kubernetes/caasp.py
@@ -64,8 +64,7 @@ class CaaSP(KubernetesBase):
 
     def _caasp_init(self):
         try:
-            self.workspace.execute(
-                "skuba cluster init --control-plane", check=True)
+            self.workspace.execute("skuba cluster init --control-plane")
         except subprocess.CalledProcessError as e:
             logger.exception('skuba cluster init failed: '
                              f'{e.stdout}\n{e.stderr}')
@@ -77,8 +76,7 @@ class CaaSP(KubernetesBase):
             self.workspace.execute(
                 "skuba node bootstrap --user sles --sudo --target"
                 f" {self.hardware.masters[0].get_ssh_ip()}"
-                f" {self.hardware.masters[0].dnsname}",
-                check=True
+                f" {self.hardware.masters[0].dnsname}"
             )
         except subprocess.CalledProcessError as e:
             logger.exception('skuba node bootstrap failed: '
@@ -90,8 +88,7 @@ class CaaSP(KubernetesBase):
             try:
                 self.workspace.execute(
                     "skuba node join --role worker --user sles --sudo"
-                    f"--target {worker.get_ssh_ip()} {worker.dnsname}",
-                    check=True
+                    f"--target {worker.get_ssh_ip()} {worker.dnsname}"
                 )
             except subprocess.CalledProcessError as e:
                 logger.exception(

--- a/tests/lib/kubernetes/caasp.py
+++ b/tests/lib/kubernetes/caasp.py
@@ -88,15 +88,11 @@ class CaaSP(KubernetesBase):
     def _caasp_join(self):
         for worker in self.hardware.workers:
             try:
-                env = os.environ.copy()
-                env['SSH_AUTH_SOCK'] = self.workspace.ssh_agent_auth_sock
-                env['SSH_AGENT_PID'] = self.workspace.ssh_agent_pid
-                res = subprocess.run(
-                    ['skuba', 'node', 'join', '--role', 'worker',
-                     '--user', 'sles', '--sudo', '--target',
-                     worker.get_ssh_ip(), worker.dnsname],
-                    env=env, check=True, capture_output=True)
-                logger.debug(res.args)
+                self.workspace.execute(
+                    "skuba node join --role worker --user sles --sudo"
+                    f"--target {worker.get_ssh_ip()} {worker.dnsname}",
+                    check=True
+                )
             except subprocess.CalledProcessError as e:
                 logger.exception(
                     f'skuba node join worker for  {worker.dnsname} failed: '

--- a/tests/lib/kubernetes/vanilla.py
+++ b/tests/lib/kubernetes/vanilla.py
@@ -85,10 +85,12 @@ class Vanilla(KubernetesBase):
     def _download_kubectl(self):
         # Download specific kubectl version
         # TODO(jhesketh): Allow setting version
+        logger.info("Downloading kubectl binary")
         wget.download(
             "https://storage.googleapis.com/kubernetes-release/release/v1.17.3"
             "/bin/linux/amd64/kubectl",
-            self.kubectl_exec
+            self.kubectl_exec,
+            bar=None
         )
         st = os.stat(self.kubectl_exec)
         os.chmod(self.kubectl_exec, st.st_mode | stat.S_IEXEC)

--- a/tests/lib/kubernetes/vanilla.py
+++ b/tests/lib/kubernetes/vanilla.py
@@ -22,7 +22,6 @@
 import logging
 import os
 import stat
-import subprocess
 import wget
 
 from abc import ABC, abstractmethod
@@ -67,11 +66,7 @@ class Vanilla(KubernetesBase):
 
         self._configure_kubernetes_client()
         self._download_kubectl()
-        try:
-            self.untaint_master()
-        except subprocess.CalledProcessError:
-            # Untainting returns exit status 1 since not all nodes are tainted.
-            pass
+        self.untaint_master()
         self._setup_flannel()
 
     def _setup_flannel(self):

--- a/tests/lib/kubernetes/vanilla.py
+++ b/tests/lib/kubernetes/vanilla.py
@@ -71,7 +71,7 @@ class Vanilla(KubernetesBase):
 
     def _setup_flannel(self):
         for node in self.hardware.nodes.values():
-            self.kubtectl(
+            self.kubectl(
                 "annotate node %s "
                 "flannel.alpha.coreos.com/public-ip-overwrite=%s "
                 "--overwrite" % (

--- a/tests/lib/rook.py
+++ b/tests/lib/rook.py
@@ -104,7 +104,8 @@ class RookCluster():
         logger.info("[build_rook] Download go")
         wget.download(
             "https://dl.google.com/go/go1.13.9.linux-amd64.tar.gz",
-            os.path.join(self.builddir, 'go-amd64.tar.gz')
+            os.path.join(self.builddir, 'go-amd64.tar.gz'),
+            bar=None,
         )
 
         logger.info("[build_rook] Unpack go")

--- a/tests/lib/workspace.py
+++ b/tests/lib/workspace.py
@@ -24,6 +24,7 @@ import uuid
 import paramiko.rsakey
 
 from tests import config
+from tests.lib.common import execute
 from tests.lib.ansible_helper import AnsibleRunner
 from tests.lib.hardware.node_base import NodeBase
 
@@ -122,6 +123,22 @@ class Workspace():
         except subprocess.CalledProcessError:
             logger.exception('Failed to add keys to agent')
             raise
+
+    def execute(self, command, capture=False, check=False,
+                disable_logger=False, env=None, chdir=None):
+        """Executes a command inside the workspace
+
+        This is a wrapper around the execute util that will automatically
+        chdir into the workspace and set some common env vars (such as the
+        ssh agent).
+        """
+        if not env:
+            env = {}
+        with self.chdir(chdir):
+            env['SSH_AUTH_SOCK'] = self.ssh_agent_auth_sock
+            env['SSH_AGENT_PID'] = self.ssh_agent_pid
+            return execute(command, capture=capture, check=check,
+                           disable_logger=disable_logger, env=env)
 
     def execute_ansible_play_raw(self, playbook: str,
                                  nodes: Dict[str, NodeBase],

--- a/tests/lib/workspace.py
+++ b/tests/lib/workspace.py
@@ -103,7 +103,7 @@ class Workspace():
         try:
             rc, stdout, stderr = execute(
                 f'ssh-agent -a {self.ssh_agent_auth_sock}',
-                check=True, capture=True
+                capture=True
             )
         except subprocess.CalledProcessError:
             logger.exception('Failed to start ssh agent')
@@ -111,12 +111,12 @@ class Workspace():
 
         self._ssh_agent_pid = stdout.split(';')[2].split('=')[1]
         try:
-            self.execute(f'ssh-add {self.private_key}', check=True)
+            self.execute(f'ssh-add {self.private_key}')
         except subprocess.CalledProcessError:
             logger.exception('Failed to add keys to agent')
             raise
 
-    def execute(self, command: str, capture=False, check=False,
+    def execute(self, command: str, capture=False, check=True,
                 disable_logger=False, env=None,
                 chdir=None) -> Tuple[int, Optional[str], Optional[str]]:
         """Executes a command inside the workspace

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2020 SUSE LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from tests.lib.common import execute
+
+logger = logging.getLogger(__name__)
+
+
+def test_command_output():
+    rc, out = execute('echo "Hello world"')
+    assert rc == 0
+    assert out is None
+
+    rc, out = execute('echo "Hello world" && >&2 echo "error"', capture=True)
+    assert out['stdout'] == "Hello world\n"
+    assert out['stderr'] == "error\n"
+
+
+def test_command_rc():
+    rc, out = execute('exit 12')
+    assert rc == 12
+    assert out is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -15,30 +15,36 @@
 import logging
 import subprocess
 
+import pytest
+
 from tests.lib.common import execute
 
 logger = logging.getLogger(__name__)
 
 
-def test_command_output():
-    rc, out = execute('echo "Hello world"')
+@pytest.mark.parametrize("disable_logger", [False, True])
+def test_command_output(disable_logger):
+    rc, out = execute('echo "Hello world"', disable_logger=disable_logger)
     assert rc == 0
     assert out is None
 
-    rc, out = execute('echo "Hello world" && >&2 echo "error"', capture=True)
+    rc, out = execute('echo "Hello world" && >&2 echo "error"', capture=True,
+                      disable_logger=disable_logger)
     assert out['stdout'] == "Hello world\n"
     assert out['stderr'] == "error\n"
 
 
-def test_command_rc():
-    rc, out = execute('exit 12')
+@pytest.mark.parametrize("disable_logger", [False, True])
+def test_command_rc(disable_logger):
+    rc, out = execute('exit 12', disable_logger=disable_logger)
     assert rc == 12
     assert out is None
 
 
-def test_command_check():
+@pytest.mark.parametrize("disable_logger", [False, True])
+def test_command_check(disable_logger):
     try:
-        rc, out = execute('exit 12', check=True)
+        rc, out = execute('exit 12', check=True, disable_logger=disable_logger)
     except subprocess.CalledProcessError as exception:
         assert exception.returncode == 12
         assert exception.stdout is None
@@ -47,7 +53,7 @@ def test_command_check():
     try:
         rc, out = execute(
             'echo "Hello world" && >&2 echo "error" && exit 1',
-            capture=True, check=True
+            capture=True, check=True, disable_logger=disable_logger
         )
     except subprocess.CalledProcessError as exception:
         assert exception.returncode == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,34 +24,40 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.parametrize("disable_logger", [False, True])
 def test_command_output(disable_logger):
-    rc, out = execute('echo "Hello world"', disable_logger=disable_logger)
+    rc, stdout, stderr = execute(
+        'echo "Hello world"', disable_logger=disable_logger)
     assert rc == 0
-    assert out is None
+    assert stdout is None
+    assert stderr is None
 
-    rc, out = execute('echo "Hello world" && >&2 echo "error"', capture=True,
-                      disable_logger=disable_logger)
-    assert out['stdout'] == "Hello world\n"
-    assert out['stderr'] == "error\n"
+    rc, stdout, stderr = execute(
+        'echo "Hello world" && >&2 echo "error"',
+        capture=True, disable_logger=disable_logger
+    )
+    assert stdout == "Hello world\n"
+    assert stderr == "error\n"
 
 
 @pytest.mark.parametrize("disable_logger", [False, True])
 def test_command_rc(disable_logger):
-    rc, out = execute('exit 12', disable_logger=disable_logger)
+    rc, stdout, stderr = execute('exit 12', disable_logger=disable_logger)
     assert rc == 12
-    assert out is None
+    assert stdout is None
+    assert stderr is None
 
 
 @pytest.mark.parametrize("disable_logger", [False, True])
 def test_command_check(disable_logger):
     try:
-        rc, out = execute('exit 12', check=True, disable_logger=disable_logger)
+        rc, stdout, stderr = execute(
+            'exit 12', check=True, disable_logger=disable_logger)
     except subprocess.CalledProcessError as exception:
         assert exception.returncode == 12
         assert exception.stdout is None
         assert exception.stderr is None
 
     try:
-        rc, out = execute(
+        rc, stdout, stderr = execute(
             'echo "Hello world" && >&2 echo "error" && exit 1',
             capture=True, check=True, disable_logger=disable_logger
         )
@@ -62,6 +68,7 @@ def test_command_check(disable_logger):
 
 
 def test_command_env():
-    rc, out = execute("echo $MYVAR",
-                      env={'MYVAR': "Hello world"}, capture=True)
-    assert out['stdout'] == "Hello world\n"
+    rc, stdout, stderr = execute(
+        "echo $MYVAR", env={'MYVAR': "Hello world"}, capture=True)
+    assert stdout == "Hello world\n"
+    assert stderr == ""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -59,3 +59,9 @@ def test_command_check(disable_logger):
         assert exception.returncode == 1
         assert exception.stdout == "Hello world\n"
         assert exception.stderr == "error\n"
+
+
+def test_command_env():
+    rc, out = execute("echo $MYVAR",
+                      env={'MYVAR': "Hello world"}, capture=True)
+    assert out['stdout'] == "Hello world\n"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,7 +40,8 @@ def test_command_output(disable_logger):
 
 @pytest.mark.parametrize("disable_logger", [False, True])
 def test_command_rc(disable_logger):
-    rc, stdout, stderr = execute('exit 12', disable_logger=disable_logger)
+    rc, stdout, stderr = execute(
+        'exit 12', disable_logger=disable_logger, check=False)
     assert rc == 12
     assert stdout is None
     assert stderr is None
@@ -65,6 +66,13 @@ def test_command_check(disable_logger):
         assert exception.returncode == 1
         assert exception.stdout == "Hello world\n"
         assert exception.stderr == "error\n"
+
+    try:
+        rc, stdout, stderr = execute(
+            'exit 1', check=False
+        )
+    except subprocess.CalledProcessError:
+        assert False, "No error should have been raised with check=False!"
 
 
 def test_command_env():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import subprocess
 
 from tests.lib.common import execute
 
@@ -33,3 +34,22 @@ def test_command_rc():
     rc, out = execute('exit 12')
     assert rc == 12
     assert out is None
+
+
+def test_command_check():
+    try:
+        rc, out = execute('exit 12', check=True)
+    except subprocess.CalledProcessError as exception:
+        assert exception.returncode == 12
+        assert exception.stdout is None
+        assert exception.stderr is None
+
+    try:
+        rc, out = execute(
+            'echo "Hello world" && >&2 echo "error" && exit 1',
+            capture=True, check=True
+        )
+    except subprocess.CalledProcessError as exception:
+        assert exception.returncode == 1
+        assert exception.stdout == "Hello world\n"
+        assert exception.stderr == "error\n"


### PR DESCRIPTION
This greatly improves the readability of a test run.

The only output should be via the logger*. The log level is controlled by pytest.

Only log things that are useful.

* The exception is Ansible which is still using sys.stdout. This will need revisiting, but I'm considering reworking Ansible into using `ansible-playbook` instead of the unsupported python api.