### PR TITLE
Allow usage of existing SSH Agent

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ passenv =
   ROOKCHECK_*
   VERIFY_SSL_CERT
   XDG_CACHE_HOME
+  SSH_AUTH_SOCK
 
 # Allow pytest enough time to finish cleanup after interrupts
 # (requires tox > 3.15.2)


### PR DESCRIPTION
This turned out to be usefull when trying libvirt backend with
qemu+ssh:// style URL where you sometime want to reuse an existing
password protected key already added to the agent