### PR TITLE
tests/config: Add date to default cluster prefix and rename default

### DIFF
--- a/tests/config.py
+++ b/tests/config.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
 import distutils.util
 import os
 import getpass
@@ -32,7 +33,8 @@ WORKSPACE_DIR = os.getenv('WORKSPACE_DIR', '/tmp/rookcheck')
 
 # Prevent cluster collisions in shared environments with a resource name prefix
 # Can safely be commented-out for local libvirt use
-CLUSTER_PREFIX = os.getenv('CLUSTER_PREFIX', '%s-rookci-' % getpass.getuser())
+CLUSTER_PREFIX = os.getenv('CLUSTER_PREFIX', 'rookcheck-%s-%s-' % (
+    getpass.getuser(), datetime.datetime.today().strftime('%Y%m%d')))
 
 # The node image by either ID or NAME
 NODE_IMAGE = os.getenv('NODE_IMAGE', "openSUSE-Leap-15.1-OpenStack-201905")

--- a/tests/lib/ansible_helper.py
+++ b/tests/lib/ansible_helper.py
@@ -18,7 +18,6 @@ import shutil
 import tarfile
 import urllib.request
 import yaml
-import subprocess
 
 from ansible.module_utils.common.collections import ImmutableDict
 from ansible.parsing.dataloader import DataLoader
@@ -152,12 +151,8 @@ class AnsibleRunner(object):
             os.path.dirname(__file__), '../assets/ansible', playbook
         ))
         logger.info(f'Running playbook {path}')
-        try:
-            self.workspace.execute(
-                f"ansible-playbook -i {self.inventory_dir} {path}")
-        except subprocess.CalledProcessError:
-            logger.exception('An error occured executing Ansible playbook')
-            Exception("An error occurred running playbook")
+        self.workspace.execute(
+            f"ansible-playbook -i {self.inventory_dir} {path}")
 
     def run_play(self, play_source):
         # Create a new results instance for each run

--- a/tests/lib/ansible_helper.py
+++ b/tests/lib/ansible_helper.py
@@ -113,12 +113,13 @@ class AnsibleRunner(object):
         # create a inventory & group_vars directory
         inventory_dir = os.path.join(workspace.working_dir, 'inventory')
         group_vars_dir = os.path.join(inventory_dir, 'group_vars')
-        if not os.path.exists(group_vars_dir):
-            os.makedirs(group_vars_dir)
+        group_vars_all_dir = os.path.join(group_vars_dir, 'all')
+        if not os.path.exists(group_vars_all_dir):
+            os.makedirs(group_vars_all_dir)
 
         # write hardware groups vars which are useful for *all* nodes
-        group_vars_all = os.path.join(group_vars_dir, 'all.yml')
-        with open(group_vars_all, 'w') as f:
+        group_vars_all_common = os.path.join(group_vars_all_dir, 'common.yml')
+        with open(group_vars_all_common, 'w') as f:
             yaml.dump(inventory_vars, f)
 
         # write node specific inventory

--- a/tests/lib/hardware/libvirt.py
+++ b/tests/lib/hardware/libvirt.py
@@ -275,7 +275,6 @@ class Hardware(HardwareBase):
 
     def _create_network(self):
         network = netaddr.IPNetwork(config.PROVIDER_LIBVIRT_NETWORK_RANGE)
-        network_name = "%s_net" % self.workspace.name
         host_ip = str(netaddr.IPAddress(network.first+1))
         netmask = str(network.netmask)
         dhcp_start = str(netaddr.IPAddress(network.first+2))
@@ -291,7 +290,7 @@ class Hardware(HardwareBase):
             </ip>
             </network>
         """ % {
-            "network_name": network_name,
+            "network_name": self.workspace.name,
             "host_ip": host_ip,
             "netmask": netmask,
             "dhcp_start": dhcp_start,

--- a/tests/lib/workspace.py
+++ b/tests/lib/workspace.py
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 class Workspace():
     def __init__(self):
         # Set up a common workspace that most modules will expect
-        self._workspace_uuid: str = str(uuid.uuid4())[:8]
+        self._workspace_uuid: str = str(uuid.uuid4())[:4]
         self._working_dir: str = self._get_working_dir()
 
         self._sshkey_name: Optional[str] = None


### PR DESCRIPTION
Having the date in the cluster prefix makes it easier to find outdated
workspace dirs. Also rename "rookci" to "rookcheck" to make it clear
where the tmp dir is coming from.
Note: This just changes the default. A user can still change the
behavior with setting CLUSTER_PREFIX.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>