### PR TITLE
Tidy up test_fixtures

### DIFF
--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -12,29 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
+
 from tests.lib.hardware.node_base import NodeRole
 
 
-rook_cluster_instance = {}
+logger = logging.getLogger(__name__)
+workspace_instance = {}
 
 
-def test_debug_scope_order(rook_cluster):
-    return
-    print("We'll deliberately fail in this job to provide some useful output")
-    print("We only see stdout from failing jobs.")
-    print("We also only see the stdout from the fixture setup at a module"
-          " level if the first job fails.")
-    assert 0
+def test_workspace_instance_scope_part1(workspace):
+    logging.info("Grabbing the provided workspace into a global variable")
+    workspace_instance[0] = workspace
 
 
-def test_rook_cluster_instance_scope_part1(rook_cluster):
-    print("The rook_cluster fixture is scoped to the module, so we should have"
-          " the same rook_cluster instance")
-    rook_cluster_instance[0] = rook_cluster
-
-
-def test_rook_cluster_instance_scope_part2(rook_cluster):
-    assert rook_cluster is rook_cluster_instance[0]
+def test_workspace_instance_scope_part2(workspace):
+    logging.info("The workspace fixture is scoped to the module, so we should"
+                 " have the same workspace instance as before")
+    assert workspace is workspace_instance[0]
 
 
 def test_hardware_node_add_remove(hardware):


### PR DESCRIPTION
We don't need to build an expensive rook cluster to make sure fixtures
are behaving how we expect. Instead use the workspace fixture.

We also don't need the debug test that was leftover from manual testing.

Also fix up the logging/output of the tests.