### PR TITLE
workspace: Move basic ansible inventory vars to workspace

### DIFF
--- a/tests/lib/ansible_helper.py
+++ b/tests/lib/ansible_helper.py
@@ -66,7 +66,7 @@ class ResultCallback(CallbackModule):
 
 
 class AnsibleRunner(object):
-    def __init__(self, workspace, nodes, inventory_vars=None):
+    def __init__(self, workspace, nodes):
         self._workspace = workspace
         # since the API is constructed for CLI it expects certain options to
         # always be set in the context object
@@ -82,8 +82,7 @@ class AnsibleRunner(object):
 
         # create inventory, use path to host config file as source or hosts in
         # a comma separated string
-        self.inventory_dir = self.create_inventory(
-            workspace, nodes, inventory_vars)
+        self.inventory_dir = self.create_inventory(workspace, nodes)
         self.inventory = InventoryManager(
             loader=self.loader, sources=self.inventory_dir)
 
@@ -108,7 +107,7 @@ class AnsibleRunner(object):
     def workspace(self):
         return self._workspace
 
-    def create_inventory(self, workspace, nodes, inventory_vars):
+    def create_inventory(self, workspace, nodes):
         # create a inventory & group_vars directory
         inventory_dir = os.path.join(workspace.working_dir, 'inventory')
         group_vars_dir = os.path.join(inventory_dir, 'group_vars')
@@ -119,7 +118,7 @@ class AnsibleRunner(object):
         # write hardware groups vars which are useful for *all* nodes
         group_vars_all_common = os.path.join(group_vars_all_dir, 'common.yml')
         with open(group_vars_all_common, 'w') as f:
-            yaml.dump(inventory_vars, f)
+            yaml.dump(workspace.ansible_inventory_vars(), f)
 
         # write node specific inventory
         inv = {

--- a/tests/lib/hardware/hardware_base.py
+++ b/tests/lib/hardware/hardware_base.py
@@ -24,7 +24,7 @@
 
 from abc import ABC, abstractmethod
 import logging
-from typing import Dict, Any, List
+from typing import Dict, List
 
 from tests.lib.distro import get_distro
 from tests.lib.hardware.node_base import NodeBase, NodeRole
@@ -119,24 +119,10 @@ class HardwareBase(ABC):
         self.execute_ansible_play(d.bootstrap_play())
 
     def execute_ansible_play_raw(self, playbook):
-        return self.workspace.execute_ansible_play_raw(
-            playbook, self.nodes, self.ansible_inventory_vars())
+        return self.workspace.execute_ansible_play_raw(playbook, self.nodes)
 
     def execute_ansible_play(self, play_source):
-        return self.workspace.execute_ansible_play(
-            play_source, self.nodes, self.ansible_inventory_vars())
-
-    def ansible_inventory_vars(self) -> Dict[str, Any]:
-        vars = {
-            'ansible_ssh_private_key_file': self.workspace.private_key,
-            'ansible_host_key_checking': False,
-            'ansible_ssh_host_key_checking': False,
-            'ansible_scp_extra_args': '-o StrictHostKeyChecking=no',
-            'ansible_ssh_extra_args': '-o StrictHostKeyChecking=no',
-            'ansible_python_interpreter': '/usr/bin/python3',
-            'rookcheck_workspace_dir': self.workspace.working_dir,
-        }
-        return vars
+        return self.workspace.execute_ansible_play(play_source, self.nodes)
 
     def _get_node_by_role(self, role: NodeRole):
         items = []


### PR DESCRIPTION
Instead of having the basic ansible variables (eg. private key, host
key checking, workspace dir, ...) in the hardware base class, move
theses to the workspace class.
That's logical given that the variables used there are defined in the
Workspace class anyway.
This also simplifies the variables that need to be passed into the
ansible executor methods.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>