### PR TITLE
node-base/tasks/opensuse_leap-15: Add basic repos

### DIFF
--- a/tests/assets/ansible/roles/node-base/tasks/main.yml
+++ b/tests/assets/ansible/roles/node-base/tasks/main.yml
@@ -23,11 +23,11 @@
   vars:
     params:
       files:
-        # eg. "opensuse_leap-15.1"
+        # eg. "opensuse_leap-15.1" or "sles-15.1"
         - "{{ ansible_distribution | replace(' ', '_') | lower }}-{{ ansible_distribution_version}}.yml"
-        # eg. "opensuse_leap-15"
+        # eg. "opensuse_leap-15" or "sles-15"
         - "{{ ansible_distribution | replace(' ', '_') |lower }}-{{ ansible_distribution_major_version}}.yml"
-        # eg. "opensuse_leap"
+        # eg. "opensuse_leap" or "sles"
         - "{{ ansible_distribution | replace(' ', '_') | lower }}.yml"
         # eg. "suse"
         - "{{ ansible_os_family | lower }}.yml"

--- a/tests/assets/ansible/roles/node-base/tasks/opensuse_leap-15.yml
+++ b/tests/assets/ansible/roles/node-base/tasks/opensuse_leap-15.yml
@@ -2,6 +2,20 @@
 
 # NOTE(toabctl): we assume here, that repositories are already configured
 
+- name: add basic repositories
+  zypper_repository:
+    name: "{{ repo.name }}"
+    repo: "{{ repo.url }}"
+    state: present
+    auto_import_keys: yes
+    overwrite_multiple: yes
+    runrefresh: yes
+  loop:
+    - { name: "pool", url: "http://download.opensuse.org/distribution/leap/{{ ansible_distribution_version }}/repo/oss/" }
+    - { name: "update", url: "http://download.opensuse.org/update/leap/{{ ansible_distribution_version }}/oss/" }
+  loop_control:
+    loop_var: repo
+
 - name: install dependencies
   zypper:
     name:


### PR DESCRIPTION
Before doing anything on a openSUSE 15 node, make sure the basic
repositories are set up.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>