### PR TITLE
hardware/hardware_base: Add limit option to prepare_nodes()

### DIFF
--- a/tests/lib/hardware/hardware_base.py
+++ b/tests/lib/hardware/hardware_base.py
@@ -117,9 +117,9 @@ class HardwareBase(ABC):
     def boot_nodes(self, masters: int = 1, workers: int = 2, offset: int = 0):
         logger.info("boot nodes")
 
-    def prepare_nodes(self):
+    def prepare_nodes(self, limit_to_nodes: List[NodeBase] = []):
         logger.info("prepare nodes")
-        self.ansible_run_playbook("playbook_node_base.yml")
+        self.ansible_run_playbook("playbook_node_base.yml", limit_to_nodes)
 
     def ansible_run_playbook(self, playbook: str,
                              limit_to_nodes: List[NodeBase] = []):

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -41,6 +41,7 @@ def test_hardware_node_add_remove(hardware):
     new_node = hardware.node_create('test1', NodeRole.WORKER, [])
     # add the node to the hardware
     hardware.node_add(new_node)
+    hardware.prepare_nodes(limit_to_nodes=[new_node])
     # we should have one more node now
     assert len(hardware.nodes.keys()) == nodes_length+1
     # drop the node again


### PR DESCRIPTION
It's needed when a extra node is added during a test and the node
needs to be prepared. With the new "limit_to_nodes" parameter, this
can be done.
Also fix the test and add the "prepare_nodes()" call with a single
node.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>