### PR TITLE
roles/node-base: Do not gather facts when waiting for nodes

### DIFF
--- a/tests/assets/ansible/playbook_node_base.yml
+++ b/tests/assets/ansible/playbook_node_base.yml
@@ -1,5 +1,12 @@
 ---
 - hosts: all
+  gather_facts: no
+  tasks:
+    - name: wait for nodes
+      wait_for_connection:
+        timeout: 300
+
+- hosts: all
   tasks:
     - name: common tasks for all nodes
       import_role:

--- a/tests/assets/ansible/roles/node-base/tasks/main.yml
+++ b/tests/assets/ansible/roles/node-base/tasks/main.yml
@@ -1,9 +1,5 @@
 ---
 # common for all nodes
-- name: wait for nodes
-  wait_for_connection:
-    timeout: 300
-
 - name: raise max open files
   sysctl:
     name: fs.file-max


### PR DESCRIPTION
The gather_facts itself can fail before wait_for_connection is
executed. That leads to an unreachable node and the following error:

fatal: [rookcheck-tom-20200605-66ad_worker_1]: UNREACHABLE! => \
  {"changed": false, "msg": "Failed to connect to the host via ssh: \
  ssh: connect to host 10.86.6.110 port 22: No route to host", \
  "unreachable": true}

No gathering facts before waiting solves that problem.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>