### PR TITLE
Add env parameters for number of masters/workers.

### DIFF
--- a/tests/config.py
+++ b/tests/config.py
@@ -36,6 +36,9 @@ WORKSPACE_DIR = os.getenv('WORKSPACE_DIR', '/tmp/rookcheck')
 CLUSTER_PREFIX = os.getenv('CLUSTER_PREFIX', 'rookcheck-%s-%s-' % (
     getpass.getuser(), datetime.datetime.today().strftime('%Y%m%d')))
 
+ROOKCHECK_MASTERS = int(os.getenv('ROOKCHECK_MASTERS', 1))
+ROOKCHECK_WORKERS = int(os.getenv('ROOKCHECK_WORKERS', 3))
+
 # The node image by either ID or NAME
 NODE_IMAGE = os.getenv('NODE_IMAGE', "openSUSE-Leap-15.1-OpenStack-201905")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,9 @@ def hardware(workspace):
     # NOTE(jhesketh): The Hardware() object is expected to take care of any
     # cloud provider abstraction. It primarily does this via libcloud.
     with Hardware(workspace) as hardware:
-        hardware.boot_nodes()
+        hardware.boot_nodes(
+            masters=config.ROOKCHECK_MASTERS,
+            workers=config.ROOKCHECK_WORKERS)
         hardware.prepare_nodes()
         yield hardware
 

--- a/tests/lib/hardware/hardware_base.py
+++ b/tests/lib/hardware/hardware_base.py
@@ -114,7 +114,7 @@ class HardwareBase(ABC):
         node.destroy()
 
     @abstractmethod
-    def boot_nodes(self, masters: int = 1, workers: int = 2, offset: int = 0):
+    def boot_nodes(self, masters: int, workers: int, offset: int = 0):
         logger.info("boot nodes")
 
     def prepare_nodes(self, limit_to_nodes: List[NodeBase] = []):

--- a/tests/lib/hardware/libvirt.py
+++ b/tests/lib/hardware/libvirt.py
@@ -348,7 +348,7 @@ class Hardware(HardwareBase):
         node = self.node_create(name, role, tags)
         self.node_add(node)
 
-    def boot_nodes(self, masters: int = 1, workers: int = 2, offset: int = 0):
+    def boot_nodes(self, masters: int, workers: int, offset: int = 0):
         super().boot_nodes(masters, workers, offset)
         threads = []
         for c in range(0, masters):

--- a/tests/lib/hardware/openstack_libcloud.py
+++ b/tests/lib/hardware/openstack_libcloud.py
@@ -344,7 +344,7 @@ class Hardware(HardwareBase):
         node.boot()
         self.node_add(node)
 
-    def boot_nodes(self, masters=1, workers=2, offset=0):
+    def boot_nodes(self, masters: int, workers: int, offset: int = 0):
         """
         Boot n nodes
         Start them at a number offset


### PR DESCRIPTION
Set default worker nodes to 3.
In a cluster it makes more sense to default to 3 nodes for
quorum reasons usually.
This also harmonize boot_nodes() call between all implementation.

fixes #94