### PR TITLE
tox.ini: Pass ENVVAR_PREFIX_FOR_DYNACONF into tox env

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ deps = -r{toxinidir}/test-requirements.txt
 commands =
   py.test -s {posargs}
 passenv =
+  ENVVAR_PREFIX_FOR_DYNACONF
   HOME
   OS_AUTH_URL
   OS_AUTH_VERSION


### PR DESCRIPTION
That's needed when sourcing a env config file and then running
tox. Otherwise, the configuration values are not recognized.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>