### PR TITLE
ansible/roles/kubernetes_vanilla: Fix stop/disable apparmor

### DIFF
--- a/tests/assets/ansible/roles/kubernetes_vanilla/tasks/common.yaml
+++ b/tests/assets/ansible/roles/kubernetes_vanilla/tasks/common.yaml
@@ -65,8 +65,12 @@
     name: kubelet.service
     enabled: yes
 
+- name: populate service facts
+  service_facts:
+
 - name: disable apparmor
   systemd:
     name: apparmor
     enabled: no
     state: stopped
+  when: "'apparmor' in services"


### PR DESCRIPTION
When the apparmor service is not available, don't do
anything. Otherwise the role fails while trying to stop the service.

This fixes:

Could not find the requested service apparmor: host

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>