### PR TITLE
Execute cd and git checkout

### DIFF
--- a/tests/lib/rook/upstream.py
+++ b/tests/lib/rook/upstream.py
@@ -59,7 +59,7 @@ class RookCluster(RookBase):
         )
         # TODO(jhesketh): Allow testing various versions of rook
         execute(
-            "pushd %s && git checkout v1.3.1 && popd"
+            "cd %s && git checkout v1.3.1"
             % os.path.join(self.builddir, 'src/github.com/rook/rook'),
             log_stderr=False
         )


### PR DESCRIPTION
Restoring the directory is unnecessary since the commands execute in a
subprocess. Also the "pushd && git checkout && popd" fail on some systems

Signed-off-by: Eric Jackson <swiftgist@gmail.com>