### PR TITLE
Fix SES deployment

### DIFF
--- a/tests/assets/ansible/roles/rook/tasks/sles-15.yml
+++ b/tests/assets/ansible/roles/rook/tasks/sles-15.yml
@@ -1,4 +1,18 @@
 ---
+- name: add repositories
+  vars:
+    repositories:
+      storage6: http://download.suse.de/ibs/SUSE/Products/Storage/6/x86_64/product/
+      storage6_updates: http://download.suse.de/ibs/SUSE/Updates/Storage/6/x86_64/update/
+  zypper_repository:
+    name: '{{ repo.key }}'
+    repo: '{{ repo.value }}'
+    state: present
+    auto_import_keys: yes
+  loop: "{{ lookup('dict', repositories) }}"
+  loop_control:
+    loop_var: repo
+
 - name: add packages
   vars:
     pkg:

--- a/tests/lib/rook/ses.py
+++ b/tests/lib/rook/ses.py
@@ -41,8 +41,9 @@ class RookSes(RookBase):
 
     # TODO: DISCUSS how to handle registry.suse.com vs registry.suse.de
     def _fix_yaml(self):
+        # 'suse.com': 'suse.de/devel/storage/7.0/containers',
         replacements = {
-            'suse.com': 'suse.de/devel/storage/7.0/containers',
+            'suse.com': 'suse.de/suse/containers/ses/6/containers',
             '# ROOK_CSI_CEPH_IMAGE': 'ROOK_CSI_CEPH_IMAGE'
         }
         for root, dirs, files in os.walk(self.ceph_dir):


### PR DESCRIPTION
Use SES6 while waiting for a proper solution for selecting
version to be released.
Storage repo had most likely been erased during a merge.