### PR TITLE
Use OS_NODE_IMAGE_ID instead of OS_NODE_IMAGE

### DIFF
--- a/config/openstack.toml
+++ b/config/openstack.toml
@@ -2,7 +2,7 @@
 
 # The node image by either ID or NAME
 # os_node_image = "openSUSE-Leap-15.1-JeOS.x86_64-OpenStack-Cloud"
-os_node_image = "b73a273d-6e63-43f2-8e73-defe0da54fd6"
+os_node_image_id = "b73a273d-6e63-43f2-8e73-defe0da54fd6"
 
 # The node size or flavour name as known by the provider
 os_node_size = "m1.medium"

--- a/tests/lib/hardware/openstack_libcloud.py
+++ b/tests/lib/hardware/openstack_libcloud.py
@@ -261,7 +261,7 @@ class Hardware(HardwareBase):
         except libcloud.common.exceptions.BaseHTTPError:
             logger.debug('No image found by id. '
                          'Falling back to search by name')
-            return self._get_image_by_name(identifier)
+            return self._get_image_by_name(settings.OS_NODE_IMAGE)
 
     def _get_image_by_name(self, name):
         # NOTE(jhesketh): In general we wouldn't expect the provider list of
@@ -353,7 +353,7 @@ class Hardware(HardwareBase):
         additional_networks = [self._network_private]
         node = Node(name, role, tags, self.conn,
                     self._get_size_by_name(settings.OS_NODE_SIZE),
-                    self._get_image(settings.OS_NODE_IMAGE),
+                    self._get_image(settings.OS_NODE_IMAGE_ID),
                     additional_networks, [self._ex_security_group],
                     self.workspace.sshkey_name)
         node.boot()


### PR DESCRIPTION
OS_NODE_IMAGE should be used when configuring the image-name
OS_NODE_IMAGE_ID should be used when configuring the image-id

Signed-off-by: Stefan Haas <shaas@suse.com>