### PR TITLE
Remove kernel-default-base

### DIFF
--- a/tests/assets/ansible/roles/node-base/tasks/sles-15.yml
+++ b/tests/assets/ansible/roles/node-base/tasks/sles-15.yml
@@ -41,6 +41,11 @@
     force: yes
     extra_args: "--force-resolution"
 
+- name: remove kernel-default-base
+  zypper:
+    name: kernel-default-base  # noqa 403
+    state: absent
+
 - name: drop firewalld
   zypper:
     name: firewalld


### PR DESCRIPTION
It turns out that kernel-default-base is causing conflicts during
skuba package update (which is using zypper)
This commit simply remove the conflicting and now unused package.