### PR TITLE
Wait for Caasp to be ready

### DIFF
--- a/tests/assets/ansible/roles/node-base/tasks/sles-15.yml
+++ b/tests/assets/ansible/roles/node-base/tasks/sles-15.yml
@@ -46,6 +46,11 @@
     name: kernel-default-base  # noqa 403
     state: absent
 
+- name: update all packages
+  zypper:
+    name: '*' # noqa 403
+    state: latest
+
 - name: drop firewalld
   zypper:
     name: firewalld


### PR DESCRIPTION
Skuba is returning "joined the cluster" before the nodes are actually
marked ready.
This commit introduces a wait for all nodes to be marked as ready.
It also add a 5s wait after that step so that skuba/zypper can release
package management lock.

Also add update of all packages in early steps because otherwise skuba
does it on its own, and the wait indicated above is more hardly
predictable. Updating at the start makes it more predictable and having
the system up to date is better anyway.