### PR TITLE
test-requirements: Install libvirt-python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 language: python
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
 
 install:
   - pip install tox
+  - sudo apt-get -y install $(tox -qq -e bindep -- -b libvirt)
 
 script:
   - tox

--- a/bindep.txt
+++ b/bindep.txt
@@ -4,7 +4,9 @@
 docker
 git
 
-libvirt-client [libvirt]
+libvirt-client [libvirt platform:rpm]
+libvirt-clients [libvirt platform:dpkg]
 libvirt-devel [libvirt platform:rpm]
+libvirt-dev [libvirt platform:dpkg]
 
 openssh [sles-caasp]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,4 +12,4 @@ pytest
 pyyaml
 wget
 # for the libvirt provider
-# libvirt-python
+libvirt-python


### PR DESCRIPTION
If it's not installed, the LIBVIRT hardware provider just
fails. That's confusing for newcomers.
The downside is that libvirt-devel needs to be installed locally (but
that's already in the bindep file)

Fixes: #116

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>