### PR TITLE
Structure ses/rook upstream the same way

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,8 +91,9 @@ def linear_rook_cluster(workspace, kubernetes):
     # fixture is preferred as it will build rook locally in a thread while
     # waiting on the infrastructure
     with RookCluster(workspace, kubernetes) as rook_cluster:
-        rook_cluster.build_rook()
-        rook_cluster.install_rook()
+        rook_cluster.build()
+        rook_cluster.preinstall()
+        rook_cluster.install()
         yield rook_cluster
 
 
@@ -107,7 +108,7 @@ def rook_cluster(workspace):
                 if settings.as_bool('_USE_THREADS'):
                     logger.info("Starting rook build in a thread")
                     build_thread = threading.Thread(
-                        target=rook_cluster.build_rook)
+                        target=rook_cluster.build())
                     build_thread.start()
 
                 # build rook thread
@@ -121,12 +122,12 @@ def rook_cluster(workspace):
                     logger.info("Re-joining rook build thread")
                     build_thread.join()
                 else:
-                    rook_cluster.build_rook()
+                    rook_cluster.build()
 
                 # NOTE(jhesketh): The upload is very slow.. may want to
                 #                 consider how to do this in a thread too but
                 #                 is more complex with ansible.
-                rook_cluster.upload_rook_image()
-                rook_cluster.install_rook()
+                rook_cluster.preinstall()
+                rook_cluster.install()
 
                 yield rook_cluster

--- a/tests/lib/rook/base.py
+++ b/tests/lib/rook/base.py
@@ -13,8 +13,12 @@
 # limitations under the License.
 
 import logging
+import os
+import time
+import re
 
-from abc import ABC
+from tests.lib import common
+from abc import ABC, abstractmethod
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +35,16 @@ class RookBase(ABC):
     def workspace(self):
         return self._workspace
 
+    @abstractmethod
+    def build(self):
+        # Having the method in child classes allows easier test writing
+        # when using threads to speed things up
+        pass
+
+    @abstractmethod
+    def preinstall(self):
+        pass
+
     def destroy(self, skip=True):
         logger.info(f"rook destroy on {self.kubernetes.hardware}")
         if skip:
@@ -40,12 +54,72 @@ class RookBase(ABC):
         # TODO(jhesketh): Uninstall rook
         pass
 
-    def execute_in_ceph_toolbox(self, command):
+    def execute_in_ceph_toolbox(self, command, log_stdout=False):
         if not self.toolbox_pod:
             self.toolbox_pod = self.kubernetes.get_pod_by_app_label(
                 "rook-ceph-tools")
 
-        return self.kubernetes.execute_in_pod(command, self.toolbox_pod)
+        return self.kubernetes.execute_in_pod(
+            command, self.toolbox_pod, log_stdout=False)
+
+    def install(self):
+        # TODO(jhesketh): We may want to provide ways for tests to override
+        #                 these
+        self.kubernetes.kubectl_apply(
+            os.path.join(self.ceph_dir, 'common.yaml'))
+        self.kubernetes.kubectl_apply(
+            os.path.join(self.ceph_dir, 'operator.yaml'))
+
+        # TODO(jhesketh): Check if sleeping is necessary
+        time.sleep(10)
+
+        self.kubernetes.kubectl_apply(
+            os.path.join(self.ceph_dir, 'cluster.yaml'))
+        self.kubernetes.kubectl_apply(
+            os.path.join(self.ceph_dir, 'toolbox.yaml'))
+
+        logger.info("Wait for OSD prepare to complete "
+                    "(this may take a while...)")
+        pattern = re.compile(r'.*rook-ceph-osd-prepare.*Completed')
+        common.wait_for_result(
+            self.kubernetes.kubectl, "--namespace rook-ceph get pods",
+            matcher=common.regex_count_matcher(pattern, 3),
+            attempts=90, interval=10)
+
+        logger.info("Wait for Ceph HEALTH_OK")
+        pattern = re.compile(r'.*HEALTH_OK')
+        common.wait_for_result(
+            self.execute_in_ceph_toolbox, "ceph status",
+            matcher=common.regex_matcher(pattern),
+            attempts=20, interval=5)
+
+        logger.info("Rook successfully installed and ready!")
+
+    # TODO: need to check this in details
+    # but Ceph features methods should belong to rook base class
+    def deploy_rbd(self):
+        self.kubernetes.kubectl_apply(
+            os.path.join(self.ceph_dir, 'csi/rbd/storageclass.yaml'))
+
+    def deploy_filesystem(self):
+        self.kubernetes.kubectl_apply(
+            os.path.join(self.ceph_dir, 'filesystem.yaml'))
+        logger.info("Wait for 2 mdses to start")
+        pattern = re.compile(r'.*rook-ceph-mds-myfs.*Running')
+        common.wait_for_result(
+            self.kubernetes.kubectl, "--namespace rook-ceph get pods",
+            log_stdout=False,
+            matcher=common.regex_count_matcher(pattern, 2),
+            attempts=20, interval=5)
+
+        logger.info("Wait for myfs to be active")
+        pattern = re.compile(r'.*active')
+        common.wait_for_result(
+            self.execute_in_ceph_toolbox, "ceph fs status myfs",
+            log_stdout=False,
+            matcher=common.regex_matcher(pattern),
+            attempts=20, interval=5)
+        logger.info("Ceph FS successfully installed and ready!")
 
     def __enter__(self):
         return self


### PR DESCRIPTION
This adds build/preinstall/install steps to both implementation.
Having a build() method is necessary in ses (though is does nothing
usefull) so we can call it early in threaded tests that will
opportunitely build rook if possible before deployment.

Move install code to base class as it is no upstream specific.

Move ceph features method (rbd, fs...) to base class too.