### PR TITLE
Fix installation of rook if ses is configured

### DIFF
--- a/tests/lib/rook/ses.py
+++ b/tests/lib/rook/ses.py
@@ -63,12 +63,19 @@ class RookSes(RookBase):
                     os.rename(src, f'{src}.back')
                     os.rename(tmp, src)
 
-    def preinstall(self):
+    def build_rook(self):
+        logger.info("Using pre-build rook images")
+
+    def upload_rook_image(self):
+        logger.info("Using pre-build rook images")
+
+    def rook_preinstall(self):
         self.kubernetes.hardware.ansible_run_playbook('playbook_ses.yaml')
         self._get_rook_files()
         self._fix_yaml()
 
-    def install(self):
+    def install_rook(self):
+        self.rook_preinstall()
         # TODO(jhesketh): We may want to provide ways for tests to override
         #                 these
         self.kubernetes.kubectl_apply(

--- a/tests/lib/rook/upstream.py
+++ b/tests/lib/rook/upstream.py
@@ -161,11 +161,3 @@ class RookCluster(RookBase):
             attempts=20, interval=5)
 
         logger.info("Rook successfully installed and ready!")
-
-    def execute_in_ceph_toolbox(self, command, log_stdout=False):
-        if not self.toolbox_pod:
-            self.toolbox_pod = self.kubernetes.get_pod_by_app_label(
-                "rook-ceph-tools")
-
-        return self.kubernetes.execute_in_pod(
-            command, self.toolbox_pod, log_stdout=False)


### PR DESCRIPTION
In case of SES as distro rook installation failed due to an incomplete implementation.

Signed-off-by: Stefan Haas <shaas@suse.com>