### PR TITLE
Set skuba to annotate only mode

### DIFF
--- a/tests/assets/ansible/roles/caasp/files/skuba-update
+++ b/tests/assets/ansible/roles/caasp/files/skuba-update
@@ -1,0 +1,7 @@
+## Path           : System/Management
+## Description    : Extra switches for skuba-update
+## Type           : string
+## Default        : ""
+## ServiceRestart : skuba-update
+#
+SKUBA_UPDATE_OPTIONS="--annotate-only"

--- a/tests/assets/ansible/roles/caasp/tasks/Suse.yaml
+++ b/tests/assets/ansible/roles/caasp/tasks/Suse.yaml
@@ -22,3 +22,11 @@
       name: '{{ pkg }}'
       state: present
       update_cache: yes
+
+- name: set skuba-update to annotate-only mode
+  copy:
+    src: skuba-update
+    dest: /etc/sysconfig/skuba-update
+    owner: root
+    group: root
+    mode: 0644


### PR DESCRIPTION
Skuba package does install a timer that triggers skuba-update program at
specific time to handle intelligent updates of running CaaSP clusters.
This is not a feature we want in rookcheck context.