### PR TITLE
Fix race condition with counting ready containers

### DIFF
--- a/tests/lib/common.py
+++ b/tests/lib/common.py
@@ -34,9 +34,9 @@ def regex_matcher(regex_pattern):
     return compare
 
 
-def regex_count_matcher(regex_pattern, matches):
+def regex_count_matcher(regex_pattern, min_matches):
     def compare(testee):
-        return len(regex_pattern.findall(testee)) == matches
+        return len(regex_pattern.findall(testee)) >= min_matches
     return compare
 
 


### PR DESCRIPTION
Rookcheck waits for 3 nodes to have OSD's prepared before continuing.
However, there is a race condition where the 4th node might come up before
the check is done causing the check to fail.

Instead the regex_count_matcher should search for a minimum amount of
matches.