### PR TITLE
This test checks if all services are up and running

### DIFF
--- a/tests/lib/kubernetes/kubernetes_base.py
+++ b/tests/lib/kubernetes/kubernetes_base.py
@@ -22,6 +22,7 @@ from abc import ABC, abstractmethod
 import os
 import kubernetes
 import logging
+import time
 from typing import List
 
 from tests.lib.common import execute
@@ -157,3 +158,17 @@ class KubernetesBase(ABC):
     def configure_kubernetes_client(self):
         kubernetes.config.load_kube_config(self.kubeconfig)
         self.v1 = kubernetes.client.CoreV1Api()
+
+    def wait_for_service(self, service, sleep=10, iteration=10,
+                         namespace="rook-ceph"):
+        found = False
+        for i in range(iteration):
+            output = self.kubectl(
+                            '-n ' + namespace + ' get service ' + service,
+                            check=False)
+            if output[0] == 0:
+                found = True
+                break
+            time.sleep(10)
+
+        return found

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2020 SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+# check if all default services are available
+def test_services(rook_cluster):
+    services = ["csi-cephfsplugin-metrics",
+                "csi-rbdplugin-metrics",
+                "rook-ceph-mgr",
+                "rook-ceph-mgr-dashboard",
+                "rook-ceph-mon-a",
+                "rook-ceph-mon-b",
+                "rook-ceph-mon-c"]
+
+    for service in services:
+        found = rook_cluster.kubernetes.wait_for_service(service)
+        if found is False:
+            pytest.fail("Could not find service %s", service)
+
+
+# check if rbd service gets started automatically
+def test_service_rbd(rook_cluster):
+    # create an ObjectStore
+    output = rook_cluster.kubernetes.kubectl_apply(
+                os.path.join(rook_cluster.ceph_dir, 'object-test.yaml'))
+
+    if output[0] != 0:
+        pytest.fail("Could not create an ObjectStore")
+
+    found = rook_cluster.kubernetes.wait_for_service("rook-ceph-rgw-my-store",
+                                                     iteration=20)
+
+    if found is False:
+        pytest.fail("rgw service has not been started automatically")


### PR DESCRIPTION
This tests is a starting point for all rook-services.

It includes in this first step checks to test if all basic services are up and running and that the RGW service gets started automatically as soon as an ObjectStore gets created

Signed-off-by: Stefan Haas <shaas@suse.com>