### PR TITLE
Wait for the workers to have their OSD's prepared

### DIFF
--- a/tests/lib/rook/base.py
+++ b/tests/lib/rook/base.py
@@ -80,7 +80,7 @@ class RookBase(ABC):
 
         logger.info("Wait for OSD prepare to complete "
                     "(this may take a while...)")
-        pattern = re.compile(r'.*rook-ceph-osd-prepare.*Completed')
+        pattern = re.compile(r'.*rook-ceph-osd-prepare.*worker.*Completed')
         common.wait_for_result(
             self.kubernetes.kubectl, "--namespace rook-ceph get pods",
             matcher=common.regex_count_matcher(pattern, 3),


### PR DESCRIPTION
Ignore any OSD containers on the master.