### PR TITLE
Test to check if all monitor-services and monitor-pods are up

### DIFF
--- a/tests/lib/kubernetes/kubernetes_base.py
+++ b/tests/lib/kubernetes/kubernetes_base.py
@@ -128,21 +128,30 @@ class KubernetesBase(ABC):
             log_stderr=log_stderr
         )
 
-    def get_pod_by_app_label(self, label, namespace="rook-ceph"):
-        return self.kubectl(
+    def get_pods_by_app_label(self, label, namespace="rook-ceph"):
+        pods_string = self.kubectl(
             '--namespace %s get pod -l app="%s"'
             ' --output custom-columns=name:metadata.name --no-headers'
             % (namespace, label)
         )[1].strip()
+        return pods_string.split('\n')
+
+    def get_services_by_app_label(self, label, namespace="rook-ceph"):
+        services_string = self.kubectl(
+            '--namespace %s get svc -l app="%s"'
+            ' --output custom-columns=name:metadata.name --no-headers'
+            % (namespace, label)
+        )[1].strip()
+        return services_string.split('\n')
 
     def execute_in_pod_by_label(self, command, label, namespace="rook-ceph",
                                 log_stdout=True, log_stderr=True):
         # Note(jhesketh): The pod isn't cached, so if running multiple commands
         #                 in the one pod consider calling the following
         #                 manually
-        pod = self.get_pod_by_app_label(label, namespace)
+        pods = self.get_pods_by_app_label(label, namespace)
         return self.execute_in_pod(
-            command, pod, namespace, log_stdout=log_stdout,
+            command, pods[0], namespace, log_stdout=log_stdout,
             log_stderr=log_stderr
         )
 

--- a/tests/lib/rook/base.py
+++ b/tests/lib/rook/base.py
@@ -56,8 +56,9 @@ class RookBase(ABC):
 
     def execute_in_ceph_toolbox(self, command, log_stdout=False):
         if not self.toolbox_pod:
-            self.toolbox_pod = self.kubernetes.get_pod_by_app_label(
+            toolbox_pods = self.kubernetes.get_pods_by_app_label(
                 "rook-ceph-tools")
+            self.toolbox_pod = toolbox_pods[0]
 
         return self.kubernetes.execute_in_pod(
             command, self.toolbox_pod, log_stdout=False)
@@ -123,8 +124,8 @@ class RookBase(ABC):
 
     def get_number_of_osds(self):
         # get number of osds
-        osds = self.kubernetes.get_pod_by_app_label("rook-ceph-osd")
-        osds = osds.count('\n') + 1
+        osds = self.kubernetes.get_pods_by_app_label("rook-ceph-osd")
+        osds = len(osds)
         logger.info("cluster has %s osd pods running", osds)
         return osds
 

--- a/tests/test_mons.py
+++ b/tests/test_mons.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2020 SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import pytest
+import yaml
+
+logger = logging.getLogger(__name__)
+
+
+# check if rbd service gets started automatically
+def test_service_mons(rook_cluster):
+    cluster_yaml = os.path.join(rook_cluster.ceph_dir, 'cluster.yaml')
+    with open(cluster_yaml, 'r') as f:
+        cluster_object = yaml.load(f, Loader=yaml.BaseLoader)
+    # get configured number of monitors
+    count = cluster_object['spec']['mon']['count']
+    count = int(count)
+    logger.info("Expecting %d monitors", count)
+
+    # get number of mon-services
+    services = rook_cluster.kubernetes.get_services_by_app_label(
+        "rook-ceph-mon")
+
+    if count != len(services):
+        pytest.fail("Expected %d mon-services but got %d",
+                    count, len(services))
+
+    # get number of mon-pods
+    pods = rook_cluster.kubernetes.get_pods_by_app_label("rook-ceph-mon")
+    if count != len(pods):
+        pytest.fail("Expected %d mon-pods but got %d",
+                    count, len(pods))


### PR DESCRIPTION
This test checks if the configured amount of monitor-services and -pods are up and running.
Signed-off-by: Stefan Haas <shaas@suse.com>