### PR TITLE
Test auto-discovery of new storage devices 

### DIFF
--- a/tests/lib/rook/base.py
+++ b/tests/lib/rook/base.py
@@ -121,6 +121,13 @@ class RookBase(ABC):
             attempts=20, interval=5)
         logger.info("Ceph FS successfully installed and ready!")
 
+    def get_number_of_osds(self):
+        # get number of osds
+        osds = self.kubernetes.get_pod_by_app_label("rook-ceph-osd")
+        osds = osds.count('\n') + 1
+        logger.info("cluster has %s osd pods running", osds)
+        return osds
+
     def __enter__(self):
         return self
 

--- a/tests/test_check_num_osd.py
+++ b/tests/test_check_num_osd.py
@@ -21,27 +21,19 @@ from tests.lib.hardware.node_base import NodeRole
 logger = logging.getLogger(__name__)
 
 
-def get_number_of_osds(rook_cluster):
-    # get number of osds
-    osds = rook_cluster.kubernetes.get_pod_by_app_label("rook-ceph-osd")
-    osds = osds.count('\n') + 1
-    logger.debug("cluster has %s osd pods running", osds)
-    return osds
-
-
 def test_osd_number(rook_cluster):
     # get number of workers
     workers = len(rook_cluster.kubernetes.hardware.workers)
     logger.debug("cluster has %s worker nodes", workers)
 
-    osds = get_number_of_osds(rook_cluster)
+    osds = rook_cluster.get_number_of_osds()
     i = 0
     while osds != workers:
         if i == 20:
             pytest.fail("rook did not add an additional osd-node")
             break
         time.sleep(10)
-        osds = get_number_of_osds(rook_cluster)
+        osds = rook_cluster.get_number_of_osds()
         i += 1
 
 
@@ -71,7 +63,7 @@ def test_add_node(rook_cluster):
         i += 1
 
     # get number of new osds
-    osds = get_number_of_osds(rook_cluster)
+    osds = rook_cluster.get_number_of_osds()
 
     i = 0
     while osds != workers_new:
@@ -79,5 +71,5 @@ def test_add_node(rook_cluster):
             pytest.fail("rook did not add an additional osd-node")
             break
         time.sleep(10)
-        osds = get_number_of_osds(rook_cluster)
+        osds = rook_cluster.get_number_of_osds()
         i += 1

--- a/tests/test_storage_addition.py
+++ b/tests/test_storage_addition.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2020 SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import time
+import pytest
+
+logger = logging.getLogger(__name__)
+
+
+def test_add_storage(rook_cluster):
+    # get number of currently configured osds
+    osds = rook_cluster.get_number_of_osds()
+    # get a worker node
+    nodes = rook_cluster.kubernetes.hardware.workers
+
+    # add a disk of 10 G the node
+    disk_name = nodes[0].disk_create(10)
+    nodes[0].disk_attach(name=disk_name)
+
+    i = 0
+    # expecting an additional osd
+    osds_expected = osds + 1
+    osds_new = rook_cluster.get_number_of_osds()
+
+    # wait for the additional osd
+    # this may take a while
+    while osds_expected != osds_new:
+        if i == 20:
+            pytest.fail("rook did not add an additional osd-node")
+            break
+        time.sleep(20)
+        osds_new = rook_cluster.get_number_of_osds()
+        i += 1


### PR DESCRIPTION
This test adds a new storage device to an existing node and checks if rook adds it automatically to the ceph-cluster.

Signed-off-by: Stefan Haas <shaas@suse.com>