### PR TITLE
Jenkinsfile.integration: add build number to cluster prefix

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -3,7 +3,20 @@
 
 def compute_node='storage-rookcheck'
 // the prefix we want to use for the rookcheck environment
-def cluster_prefix="${currentBuild.fullProjectName.replace('/', '_')}-${currentBuild.number}_"
+// def cluster_prefix="${currentBuild.fullProjectName.replace('/', '_')}-${currentBuild.number}_"
+//
+// We need to set cluster_prefix as short as possible, there are two reasons
+// for this:
+// 1) too long node names constructed from cluster_prefix make kubectl annotate
+//    fails when the network isn't set up and the name is long. This is possibly
+//    an upstream kubernetes bug that we need to investigate.
+// 2) it is not super usable to operate with long names. For example, when using
+//    openstack client to list any kind of resources in terminal like servers,
+//    volumes, etc. the output tables turn into barely readable ascii soup.
+
+def branch = params.BRANCH_NAME.toLowerCase()
+def cluster_prefix = 'rkck-' + \
+    branch.startsWith('pr-') ? branch.replace('-','') + '-' + params.BUILD_NUMBER + '-' : 'jenkins-'
 
 pipeline {
     agent {
@@ -23,12 +36,7 @@ pipeline {
     }
 
     environment {
-        // ROOKCHECK_CLUSTER_PREFIX = "${cluster_prefix}"
-        // FIXME(jhesketh): ${cluster_prefix} is too long for a node name.
-        //                  kubectl annotate fails when the network isn't set
-        //                  up and the name is long. This is possibly an
-        //                  upstream kubernetes bug that I need to investigate.
-        ROOKCHECK_CLUSTER_PREFIX = "rookcheck-jen"
+        ROOKCHECK_CLUSTER_PREFIX = "${cluster_prefix}"
         OS_CLOUD = "${params.OS_CLOUD}"
         ROOKCHECK_OS_EXTERNAL_NETWORK = "${params.OS_EXTERNAL_NETWORK}"
         ROOKCHECK_OS_FLAVOR = "${params.OS_FLAVOR}"


### PR DESCRIPTION
Include build number in cluster prefix for PR triggered jobs.

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>