### PR TITLE
Add in selinux requirement to help with redhat distros

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -10,3 +10,6 @@ libvirt-devel [libvirt platform:rpm]
 libvirt-dev [libvirt platform:dpkg]
 
 openssh [sles-caasp]
+
+libselinux-python [platform:redhat-7 !platform:redhat-8]
+python3-libselinux [platform:redhat !platform:redhat-7]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,6 +10,7 @@ openstacksdk
 paramiko
 pytest
 pyyaml
+selinux
 wget
 # for the libvirt provider
 libvirt-python


### PR DESCRIPTION
See https://dmsimard.com/2016/01/08/selinux-python-virtualenv-chroot-and-ansible-dont-play-nice/