### PR TITLE
Allow passing extra-vars to ansible

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -41,5 +41,9 @@ _use_free_strategy = false
 # removed from the disk.
 _remove_workspace = true
 
+# Allow passing extra variables to Ansible (below as JSON)
+# example: export ROOKCHECK_ANSIBLE_EXTRA_VARS='{"extra_repos":{"storage_latest": "http://myextra.repo/"}}'
+ansible_extra_vars = ""
+
 # You will only need to edit the config relating to your hardware provider
 dynaconf_include = ["libvirt.toml", "openstack.toml", "aws_ec2.toml", "rook_upstream.toml", "ses.toml"]

--- a/tests/assets/ansible/roles/caasp/tasks/Suse.yaml
+++ b/tests/assets/ansible/roles/caasp/tasks/Suse.yaml
@@ -6,13 +6,13 @@
       caasp_updates: http://download.suse.de/ibs/SUSE/Updates/SUSE-CAASP/4.0/x86_64/update/
       suse_ca: "http://download.suse.de/ibs/SUSE:/CA/SLE_{{ ansible_distribution_major_version }}_SP{{ ansible_distribution_release }}/"
   zypper_repository:
-    name: '{{ repo.key }}'
-    repo: '{{ repo.value }}'
+    name: '{{ _repo.key }}'
+    repo: '{{ _repo.value }}'
     state: present
     auto_import_keys: yes
   loop: "{{ lookup('dict', repositories) }}"
   loop_control:
-    loop_var: repo
+    loop_var: _repo
 
 - name: add packages
   vars:

--- a/tests/assets/ansible/roles/node_base/defaults/main.yaml
+++ b/tests/assets/ansible/roles/node_base/defaults/main.yaml
@@ -1,0 +1,2 @@
+---
+extra_repos: {}

--- a/tests/assets/ansible/roles/node_base/tasks/opensuse_leap-15.yml
+++ b/tests/assets/ansible/roles/node_base/tasks/opensuse_leap-15.yml
@@ -4,8 +4,8 @@
 
 # - name: add basic repositories
 #   zypper_repository:
-#     name: "{{ repo.name }}"
-#     repo: "{{ repo.url }}"
+#     name: "{{ _repo.name }}"
+#     repo: "{{ _repo.url }}"
 #     state: present
 #     auto_import_keys: yes
 #     overwrite_multiple: yes
@@ -14,7 +14,18 @@
 #     - { name: "pool", url: "http://download.opensuse.org/distribution/leap/{{ ansible_distribution_version }}/repo/oss/" }
 #     - { name: "update", url: "http://download.opensuse.org/update/leap/{{ ansible_distribution_version }}/oss/" }
 #   loop_control:
-#     loop_var: repo
+#     loop_var: _repo
+
+- name: add extra repositories
+  zypper_repository:
+    name: '{{ _repo.key }}'
+    repo: '{{ _repo.value }}'
+    priority: 50
+    state: present
+    auto_import_keys: yes
+  loop: "{{ lookup('dict', extra_repos, wantlist=True) }}"
+  loop_control:
+    loop_var: _repo
 
 - name: install dependencies
   zypper:

--- a/tests/assets/ansible/roles/node_base/tasks/sles-15.yml
+++ b/tests/assets/ansible/roles/node_base/tasks/sles-15.yml
@@ -4,8 +4,8 @@
   block:
     - name: add basic repositories
       zypper_repository:
-        name: "{{ repo.name }}"
-        repo: "{{ repo.url }}"
+        name: "{{ _repo.name }}"
+        repo: "{{ _repo.url }}"
         state: present
         auto_import_keys: yes
         overwrite_multiple: yes
@@ -28,10 +28,21 @@
         - name: "sle_server_updates"
           url: "http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/{{ sle_major }}-SP{{ sle_minor }}/x86_64/update/"
       loop_control:
-        loop_var: repo
+        loop_var: _repo
   vars:
     sle_major: "{{ ansible_distribution_version.split('.')[0] }}"
     sle_minor: "{{ ansible_distribution_version.split('.')[1] }}"
+
+- name: add extra repositories
+  zypper_repository:
+    name: '{{ _repo.key }}'
+    repo: '{{ _repo.value }}'
+    priority: 50
+    state: present
+    auto_import_keys: yes
+  loop: "{{ lookup('dict', extra_repos, wantlist=True) }}"
+  loop_control:
+    loop_var: _repo
 
 - name: install dependencies
   zypper:

--- a/tests/assets/ansible/roles/rook/tasks/sles-15.1.yml
+++ b/tests/assets/ansible/roles/rook/tasks/sles-15.1.yml
@@ -5,13 +5,13 @@
       storage: http://download.suse.de/ibs/SUSE/Products/Storage/6/x86_64/product/
       storage_updates: http://download.suse.de/ibs/SUSE/Updates/Storage/6/x86_64/update/
   zypper_repository:
-    name: '{{ repo.key }}'
-    repo: '{{ repo.value }}'
+    name: '{{ _repo.key }}'
+    repo: '{{ _repo.value }}'
     state: present
     auto_import_keys: yes
   loop: "{{ lookup('dict', repositories) }}"
   loop_control:
-    loop_var: repo
+    loop_var: _repo
 
 - name: add packages
   vars:

--- a/tests/assets/ansible/roles/rook/tasks/sles-15.2.yml
+++ b/tests/assets/ansible/roles/rook/tasks/sles-15.2.yml
@@ -5,13 +5,13 @@
       storage: http://download.suse.de/ibs/SUSE/Products/Storage/7/x86_64/product/
       storage_updates: http://download.suse.de/ibs/SUSE/Updates/Storage/7/x86_64/update/
   zypper_repository:
-    name: '{{ repo.key }}'
-    repo: '{{ repo.value }}'
+    name: '{{ _repo.key }}'
+    repo: '{{ _repo.value }}'
     state: present
     auto_import_keys: yes
   loop: "{{ lookup('dict', repositories) }}"
   loop_control:
-    loop_var: repo
+    loop_var: _repo
 
 - name: add packages
   vars:

--- a/tests/lib/hardware/hardware_base.py
+++ b/tests/lib/hardware/hardware_base.py
@@ -28,8 +28,8 @@ from typing import Dict, List
 import threading
 
 from tests.lib.hardware.node_base import NodeBase, NodeRole
-
 from tests.lib.workspace import Workspace
+from tests.config import settings
 
 logger = logging.getLogger(__name__)
 
@@ -125,7 +125,8 @@ class HardwareBase(ABC):
         self.ansible_run_playbook("playbook_node_base.yml", limit_to_nodes)
 
     def ansible_run_playbook(self, playbook: str,
-                             limit_to_nodes: List[NodeBase] = []):
+                             limit_to_nodes: List[NodeBase] = [],
+                             extra_vars=settings.ANSIBLE_EXTRA_VARS):
         path = os.path.abspath(os.path.join(
             os.path.dirname(__file__), '../../assets/ansible', playbook
         ))
@@ -134,11 +135,15 @@ class HardwareBase(ABC):
             limit = "--limit " + ":".join([n.name for n in limit_to_nodes])
         else:
             limit = ""
+        if extra_vars:
+            extra_vars = f"--extra-vars '{extra_vars}'"
+        else:
+            extra_vars = ""
 
         logger.info(f'Running playbook {path} ({limit})')
         self.workspace.execute(
             f"ansible-playbook -i {self._ansible_inventory_dir} "
-            f"{limit} {path}",
+            f"{limit} {extra_vars} {path}",
             logger_name=f"ansible {playbook}")
 
     def _ansible_create_inventory(self):


### PR DESCRIPTION
In order to pass custom repo (but that could be anything), you used
to have to update yaml repo definition.
This PR allows you to easily pass vars to ansible by setting an
env variable ROOKCHECK_ANSIBLE_EXTRA_VARS:

export ROOKCHECK_ANSIBLE_EXTRA_VARS='{"repo":{"storage_latest": "http://download.suse.de/ibs/SUSE:/SLE-15-SP2:/Update:/Products:/SES7/images/repo/SUSE-Enterprise-Storage-7-POOL-x86_64-Media1/"}}'

repo var was renamed to _repo within ansible playbook to avoid
conflicts during lookup