### PR TITLE
config & examples: Switch to openSUSE 15.2

### DIFF
--- a/config/libvirt.toml
+++ b/config/libvirt.toml
@@ -15,7 +15,7 @@ libvirt_network_subnet = 26
 # The qcow2 image that will be used for libvirt. The image must
 # contain cloud-init. This can be an system path or a URL which rookcheck will
 # download.
-libvirt_image = "https://download.opensuse.org/distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-OpenStack-Cloud.qcow2"
+libvirt_image = "https://download.opensuse.org/distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-OpenStack-Cloud.qcow2"
 
 # Memory use for libvirt VMs (in GB)
 libvirt_vm_memory = 8

--- a/config/openstack.toml
+++ b/config/openstack.toml
@@ -1,7 +1,7 @@
 [default]
 
 # The node image by either ID or NAME
-# os_node_image = "openSUSE-Leap-15.1-JeOS.x86_64-OpenStack-Cloud"
+# os_node_image = "openSUSE-Leap-15.2-JeOS.x86_64-OpenStack-Cloud"
 os_node_image = "b73a273d-6e63-43f2-8e73-defe0da54fd6"
 
 # The node size or flavour name as known by the provider

--- a/examples/libvirt-caasp-ses.env
+++ b/examples/libvirt-caasp-ses.env
@@ -10,4 +10,4 @@ export ROOKCHECK_LIBVIRT_CONNECTION="qemu:///system"
 export ROOKCHECK_LIBVIRT_VM_MEMORY="8"
 export ROOKCHECK_DISTRO=SLES_CaaSP
 export ROOKCHECK_NODE_IMAGE_USER=sles
-export ROOKCHECK_LIBVIRT_IMAGE="http://download.suse.de/install/SLE-15-SP1-JeOS-QU3/SLES15-SP1-JeOS.x86_64-15.1-OpenStack-Cloud-QU3.qcow2"
+export ROOKCHECK_LIBVIRT_IMAGE="http://download.opensuse.org/distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-OpenStack-Cloud.qcow2"

--- a/examples/libvirt-k8s-upstream.env
+++ b/examples/libvirt-k8s-upstream.env
@@ -8,4 +8,4 @@ export ROOKCHECK_HARDWARE_PROVIDER="LIBVIRT"
 export ROOKCHECK_LIBVIRT_CONNECTION="qemu:///system"
 export ROOKCHECK_LIBVIRT_VM_MEMORY="8"
 export ROOKCHECK_NODE_IMAGE_USER=opensuse
-export ROOKCHECK_LIBVIRT_IMAGE="http://download.opensuse.org/distribution/leap/15.1/jeos/openSUSE-Leap-15.1-JeOS.x86_64-OpenStack-Cloud.qcow2"
+export ROOKCHECK_LIBVIRT_IMAGE="http://download.opensuse.org/distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-OpenStack-Cloud.qcow2"

--- a/examples/openstack-k8s-upstream.env
+++ b/examples/openstack-k8s-upstream.env
@@ -10,4 +10,4 @@ export ROOKCHECK_HARDWARE_PROVIDER="OPENSTACK"
 # the username to log into the image
 # export ROOKCHECK_NODE_IMAGE_USER=opensuse
 # the OpenStack image to use (must be available on the OpenStack cloud)
-# export ROOKCHECK_OS_NODE_IMAGE=openSUSE-Leap-15.1-JeOS.x86_64-OpenStack-Cloud
+# export ROOKCHECK_OS_NODE_IMAGE=openSUSE-Leap-15.2-JeOS.x86_64-OpenStack-Cloud


### PR DESCRIPTION
openSUSE 15.2 got released some time ago. Use that by default instead
of 15.1.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>