### PR TITLE
Add test for increasing/decreasing the number of active MON pods

### DIFF
--- a/tests/lib/rook/base.py
+++ b/tests/lib/rook/base.py
@@ -129,6 +129,13 @@ class RookBase(ABC):
         logger.info("cluster has %s osd pods running", osds)
         return osds
 
+    def get_number_of_mons(self):
+        # get number of mons
+        mons = self.kubernetes.get_pods_by_app_label("rook-ceph-mon")
+        mons = len(mons)
+        logger.info("cluster has %s mon pods running", mons)
+        return mons
+
     def __enter__(self):
         return self
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -245,3 +245,55 @@ def test_add_storage(rook_cluster):
         time.sleep(10)
         osds_new = rook_cluster.get_number_of_osds()
         i += 1
+
+
+def test_mons_up_down(rook_cluster):
+    cluster_yaml = os.path.join(rook_cluster.ceph_dir, 'cluster.yaml')
+
+    with open(cluster_yaml, 'r') as f:
+        content = yaml.full_load(f)
+        mons = int(content['spec']['mon']['count'])
+
+    mon_pods = rook_cluster.get_number_of_mons()
+
+    logger.info("Monitors to deploy by default: %d", mons)
+    logger.info("Monitor pods actually running now: %d", mon_pods)
+
+    assert mon_pods == mons
+
+    deltamon = 2
+
+    content['spec']['mon']['count'] = mons + deltamon
+    content['spec']['mon']['allowMultiplePerNode'] = True
+
+    cluster_yaml_modded = os.path.join(
+        rook_cluster.ceph_dir, 'cluster_modded.yaml')
+
+    with open(cluster_yaml_modded, 'w') as f:
+        yaml.dump(content, f)
+
+    logger.info("About to increase the number of monitors by %d", deltamon)
+
+    rook_cluster.kubernetes.kubectl_apply(cluster_yaml_modded)
+    rook_cluster.kubernetes.wait_for_pods_by_app_label(
+        "rook-ceph-mon", count=mons+deltamon)
+
+    mon_pods = rook_cluster.get_number_of_mons()
+
+    logger.info("Monitor pods actually running now: %d", mon_pods)
+
+    assert mon_pods == mons + deltamon
+
+    logger.info("Attempting to restore the number of monitors to %d", mons)
+
+    rook_cluster.kubernetes.kubectl_apply(cluster_yaml)
+
+    check = 1
+    mon_pods = rook_cluster.get_number_of_mons()
+
+    while (check <= 60) and (mon_pods != mons):
+        time.sleep(10)
+        mon_pods = rook_cluster.get_number_of_mons()
+        check += 1
+
+    assert mon_pods == mons


### PR DESCRIPTION
* First we make sure the expected (default) number of MON pods are running
* We increase the number of expected MON pods by 2, allowing more than one MON pods per node
* We make sure the new expected number of MON pods are all running
* Finally, we decrease the number of MON pods down to the default number, also disallowing more than one MON pods per node