### PR TITLE
hardware/libvirt: Change qemu cache mode to writeback

### DIFF
--- a/tests/lib/hardware/libvirt.py
+++ b/tests/lib/hardware/libvirt.py
@@ -187,7 +187,7 @@ class Node(NodeBase):
         block_device = self._get_next_disk_letter()
         disk = textwrap.dedent("""
             <disk type='file' device='disk'>
-                <driver name='qemu' type='qcow2' cache='none'/>
+                <driver name='qemu' type='qcow2' cache='writeback'/>
                 <source file='%(disk_path)s'/>
                 <target dev='%(block_device)s' bus='virtio'/>
             </disk>
@@ -262,7 +262,7 @@ class Node(NodeBase):
                 <devices>
                     <emulator>/usr/bin/qemu-system-x86_64</emulator>
                     <disk type='file' device='disk'>
-                        <driver name='qemu' type='qcow2' cache='none'/>
+                        <driver name='qemu' type='qcow2' cache='writeback'/>
                         <source file='%(image)s'/>
                         <target dev='vda' bus='virtio'/>
                     </disk>


### PR DESCRIPTION
With cache=none, I'm getting an error like:

libvirt: QEMU Driver error : internal error: \
  qemu unexpectedly closed the monitor: [...] file system may \
  not support O_DIRECT

This happens on an ext4 filesystem. Switching to a
different cache mode solves the problem.