### PR TITLE
examples/libvirt-caasp-ses: Use SLE15SP1 image instead of openSUSE

### DIFF
--- a/examples/libvirt-caasp-ses.env
+++ b/examples/libvirt-caasp-ses.env
@@ -10,4 +10,4 @@ export ROOKCHECK_LIBVIRT_CONNECTION="qemu:///system"
 export ROOKCHECK_LIBVIRT_VM_MEMORY="8"
 export ROOKCHECK_DISTRO=SLES_CaaSP
 export ROOKCHECK_NODE_IMAGE_USER=sles
-export ROOKCHECK_LIBVIRT_IMAGE="http://download.opensuse.org/distribution/leap/15.2/appliances/openSUSE-Leap-15.2-JeOS.x86_64-OpenStack-Cloud.qcow2"
+export ROOKCHECK_LIBVIRT_IMAGE="http://download.suse.de/install/SLE-15-SP1-JeOS-QU4/SLES15-SP1-JeOS.x86_64-15.1-OpenStack-Cloud-QU4.qcow2"


### PR DESCRIPTION
We need to install CaaSP on top of SLE. openSUSE won't work.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>