### PR TITLE
config: Include libvirt.toml config

### DIFF
--- a/tests/config.py
+++ b/tests/config.py
@@ -27,6 +27,7 @@ settings = Dynaconf(
     settings_files=[
         os.path.join(settings_dir, 'settings.toml'),
         os.path.join(settings_dir, 'openstack.toml'),
+        os.path.join(settings_dir, 'libvirt.toml'),
         os.path.join(settings_dir, 'aws_ec2.toml'),
         os.path.join(settings_dir, 'rook_upstream.toml'),
         os.path.join(settings_dir, 'ses.toml'),

--- a/tests/test_playground.py
+++ b/tests/test_playground.py
@@ -19,6 +19,6 @@ logger = logging.getLogger(__name__)
 
 
 def test_playground(workspace, hardware, kubernetes):
-    #rook_cluster = linear_rook_cluster
+    # rook_cluster = linear_rook_cluster
     import code
     code.interact(local=locals())


### PR DESCRIPTION
It's needed to have the libvirt variables available when using the
libvirt backend. Otherwise it fails with:

dynaconf.vendor.box.exceptions.BoxKeyError: "'DynaBox' object has \
  no attribute 'network_range'"

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>