### PR TITLE
lib/hardware: Unify and abstract disk_create method

### DIFF
--- a/tests/lib/hardware/aws_ec2.py
+++ b/tests/lib/hardware/aws_ec2.py
@@ -69,7 +69,7 @@ class Node(NodeBase):
 
         if self._role == NodeRole.WORKER:
             for i in range(0, settings.WORKER_INITIAL_DATA_DISKS):
-                disk_name = self.disk_create()
+                disk_name = self.disk_create(10)
                 self.disk_attach(name=disk_name)
 
     def get_ssh_ip(self) -> str:
@@ -92,7 +92,8 @@ class Node(NodeBase):
             if v['volume'].id == volume.id:
                 return k
 
-    def disk_create(self, capacity='10'):
+    def disk_create(self, capacity):
+        super().disk_create(capacity)
         if not self._instance:
             raise Exception("Can not create a disk until a node is created")
         suffix = ''.join(random.choice(string.ascii_lowercase)
@@ -100,12 +101,12 @@ class Node(NodeBase):
         name = f"{self._name}-volume-{suffix}"
         volume = self._ec2.create_volume(
             AvailabilityZone=self._instance.placement['AvailabilityZone'],
-            Size=int(capacity),
+            Size=capacity,
         )
         volume.create_tags(
             Tags=[{"Key": "Name", "Value": name}])
         self._disks[name] = {'volume': volume, 'attached': False}
-        logger.info(f"Volume {name} created - ({volume}) / size={capacity}")
+        logger.info(f"disk {name} ({volume}) created")
         return name
 
     def _get_next_device_name(self):

--- a/tests/lib/hardware/libvirt.py
+++ b/tests/lib/hardware/libvirt.py
@@ -76,7 +76,7 @@ class Node(NodeBase):
         self._dom.create()
         if self._role == NodeRole.WORKER:
             for i in range(0, settings.WORKER_INITIAL_DATA_DISKS):
-                disk_name = self.disk_create()
+                disk_name = self.disk_create(10)
                 self.disk_attach(name=disk_name)
         self._ips = self._get_ips()
         self._wait_for_ssh()
@@ -146,22 +146,24 @@ class Node(NodeBase):
         logger.info(f"node {self.name}: created qcow2 backing file under"
                     f"{self._snap_img_path}")
 
-    def disk_create(self, capacity='10G'):
+    def disk_create(self, capacity):
         """
         Create a disk volume
         """
+        super().disk_create(capacity)
+        capacity_gb = f"{capacity}G"
         suffix = ''.join(random.choice(string.ascii_lowercase)
                          for i in range(5))
         name = f"{self._name}-volume-{suffix}"
         disk_path = os.path.join(self._workspace.working_dir,
                                  f"{name}.qcow2")
-        execute(f"qemu-img create -f qcow2 {disk_path} {capacity}")
+        execute(f"qemu-img create -f qcow2 {disk_path} {capacity_gb}")
         self._disks[name] = {
             'path': disk_path,
             'attached': False,
             'xml': None
         }
-        logger.info(f"Volume {name} / size={capacity} created")
+        logger.info(f"disk {name} created")
         return name
 
     def _get_next_disk_letter(self):

--- a/tests/lib/hardware/node_base.py
+++ b/tests/lib/hardware/node_base.py
@@ -57,11 +57,11 @@ class NodeBase(ABC):
     # disk_attach
     # disk_detach
     @abstractmethod
-    def disk_create(self, capacity):
+    def disk_create(self, capacity: int):
         """
         Create a disk volume
         """
-        pass
+        logger.info(f"creating disk with capacity {capacity} GB ...")
 
     @abstractmethod
     def disk_attach(self, capacity):

--- a/tests/lib/hardware/openstack_sdk.py
+++ b/tests/lib/hardware/openstack_sdk.py
@@ -73,7 +73,7 @@ class Node(NodeBase):
         logger.info(f"Node {self._name} has IP {self._floating_ip}")
         if self._role == NodeRole.WORKER:
             for i in range(0, settings.WORKER_INITIAL_DATA_DISKS):
-                disk_name = self.disk_create()
+                disk_name = self.disk_create(10)
                 self.disk_attach(name=disk_name)
 
     def get_ssh_ip(self) -> str:
@@ -84,14 +84,15 @@ class Node(NodeBase):
             if v['volume'].id == volume.id:
                 return k
 
-    def disk_create(self, capacity='10'):
+    def disk_create(self, capacity):
+        super().disk_create(capacity)
         suffix = ''.join(random.choice(string.ascii_lowercase)
                          for i in range(5))
         name = f"{self._name}-volume-{suffix}"
         volume = self._conn.create_volume(capacity, name=name,
                                           delete_on_termination=True)
         self._disks[name] = {'volume': volume, 'attached': False}
-        logger.info(f"Volume {name} created - ({volume.id}) / size={capacity}")
+        logger.info(f"disk {name} ({volume.id}) created")
         return name
 
     def disk_attach(self, name=None, volume=None):


### PR DESCRIPTION
Create an abstract disk_create() method in the HardwareBase
class. That way, it's clear that this method expects an int for the
disk capacity in GB.
This also fixes the disk deployment for libvirt where
test_add_storage() test failed because the rook-discover pod didn't
use the newly created disk (due to "Insufficient space (\u003c5GB)").
The extra qcow2 disk that was created for libvirt had a size of 512
byte.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>