### PR TITLE
rook/base: Wait for rook-ceph-tools container before using it

### DIFF
--- a/tests/lib/rook/base.py
+++ b/tests/lib/rook/base.py
@@ -87,6 +87,13 @@ class RookBase(ABC):
             matcher=common.regex_count_matcher(pattern, 3),
             attempts=120, interval=15)
 
+        logger.info("Wait for rook-ceph-tools running")
+        pattern = re.compile(r'.*rook-ceph-tools.*Running')
+        common.wait_for_result(
+            self.kubernetes.kubectl, "--namespace rook-ceph get pods",
+            matcher=common.regex_count_matcher(pattern, 1),
+            attempts=30, interval=10)
+
         logger.info("Wait for Ceph HEALTH_OK")
         pattern = re.compile(r'.*HEALTH_OK')
         common.wait_for_result(


### PR DESCRIPTION
After the OSDs got created, we currently used directly the
rook-ceph-tools container to check the ceph cluster status.
That might fail with:

error: unable to upgrade connection: container not \
  found ("rook-ceph-tools")

in the case container is not yet running. So wait for the
rook-ceph-tools container before checking the cluster status.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>