### PR TITLE
tox: Add summary report at the end of a pytest run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -83,3 +83,4 @@ log_date_format = %H:%M:%S
 
 log_cli = True
 log_cli_level = INFO
+addopts = -rA


### PR DESCRIPTION
That can be done via the -rA options. See [1]

[1]
https://docs.pytest.org/en/latest/usage.html#detailed-summary-report

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>