### PR TITLE
rook/base: Set rook operator log level to debug and wait for it

### DIFF
--- a/tests/lib/rook/base.py
+++ b/tests/lib/rook/base.py
@@ -89,9 +89,10 @@ class RookBase(ABC):
 
         logger.info("Wait for OSD prepare to complete "
                     "(this may take a while...)")
-        pattern = re.compile(r'.*rook-ceph-osd-prepare.*worker.*Completed')
+        pattern = re.compile(r'.*rook-ceph-osd-prepare.*Completed')
         common.wait_for_result(
-            self.kubernetes.kubectl, "--namespace rook-ceph get pods",
+            self.kubernetes.kubectl, "--namespace rook-ceph get pods"
+            " -l app=rook-ceph-osd-prepare",
             matcher=common.regex_count_matcher(pattern, 3),
             attempts=120, interval=15)
 


### PR DESCRIPTION
For understanding problems with test cases, it's usually useful to
have more information from the rook operator. So set the log level to
DEBUG.
Also do not unconditionally wait 10 seconds but instead wait for the
operator to be running.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>