### PR TITLE
Jenkinsfile.integration: set junit suite name to differ between the test envs

### DIFF
--- a/Jenkinsfile.integration
+++ b/Jenkinsfile.integration
@@ -50,7 +50,7 @@ pipeline {
                     }
                     steps{
                         sh "env"
-                        sh "tox -epy3 --workdir opensuse_venv -- --junitxml junit-results/openSUSE_k8s.xml tests/test_basic.py"
+                        sh "tox -epy3 --workdir opensuse_venv -- -o junit_suite_name=openSUSE_k8s --junitxml junit-results/openSUSE_k8s.xml tests/test_basic.py"
                     }
                 }
                 stage('SLES_CaaSP') {
@@ -67,7 +67,7 @@ pipeline {
                     }
                     steps{
                         sh "env"
-                        sh "tox -epy3 --workdir sles_venv -- --junitxml junit-results/SLES_CaaSP.xml tests/test_basic.py"
+                        sh "tox -epy3 --workdir sles_venv -- -o junit_suite_name=SLES_CaaSP --junitxml junit-results/SLES_CaaSP.xml tests/test_basic.py"
                     }
                 }
             }


### PR DESCRIPTION
That's useful for the junit output to have more data about the test
environment.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>