### PR TITLE
Increase the amount of time to wait for mon changes

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -291,7 +291,7 @@ def test_mons_up_down(rook_cluster):
     check = 1
     mon_pods = rook_cluster.get_number_of_mons()
 
-    while (check <= 60) and (mon_pods != mons):
+    while (check <= 180) and (mon_pods != mons):
         time.sleep(10)
         mon_pods = rook_cluster.get_number_of_mons()
         check += 1


### PR DESCRIPTION
Apparently it takes a very long time to settle (5-10min) to a lower
number of mons. I'm not sure why. This is possibly just k8s deciding
when a good time is  do an acount. Nevertheless, give this a bit more
room to move.