### PR TITLE
Add option to leave cluster available after run

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -35,7 +35,13 @@ _use_threads = false
 # TODO(jhesketh): This may not be used anymore.
 _use_free_strategy = false
 
-# If set to True, the workspacing and all created files from a test will be
+# Set _tear_down_cluster to False to keep the nodes and all the associated
+# resources available after rookcheck has finished. Keep in mind that the
+# created resources will need cleaning up manually afterwards.
+# NOTE: This option forces _remove_workspace to be False.
+_tear_down_cluster = true
+
+# If set to True, the workspace and all created files from a test will be
 # removed from the disk.
 _remove_workspace = true
 

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -33,6 +33,29 @@ Running an individual test or set of tests:
 Debugging
 ---------
 
+You can leave the built environment available by `setting _tear_down_cluster`
+to False.
+
+.. code-block:: bash
+
+    export ROOKCHECK__TEAR_DOWN_CLUSTER="FALSE"
+
+You can then access the kubeconfig and ansible inventory files among other
+resources in the workspace (defined by `workspace_dir`). This is usually
+something like `/tmp/rookcheck*`.
+
+If Kubernetes was set up, you can access the binaries used from there too.
+For example:
+
+.. code-block:: bash
+
+    cd /tmp/rookcheck/rookcheck-josh-75f5 # (substitute with your build name)
+    ./bin/kubectl --kubeconfig kubeconfig get all --all-namespaces
+
+    # Or if you're building SES, use
+    ./bin/kubectl --kubeconfig cluster/admin.conf get all --all-namespaces
+
+
 Dropping to `PDB (Python Debugger) <http://docs.python.org/library/pdb.html>`_
 on failure:
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ import os
 import pytest
 import threading
 
-from tests.config import settings
+from tests.config import settings, converter
 from tests.lib import common
 from tests.lib.workspace import Workspace
 
@@ -134,7 +134,7 @@ def _print_config():
 def _check_docker_requirement():
     logger.debug("Checking if docker is running...")
     if settings.DISTRO == 'openSUSE_k8s' and \
-            settings.as_bool('BUILD_ROOK_FROM_GIT'):
+            converter('@bool', settings.UPSTREAM_ROOK.BUILD_ROOK_FROM_GIT):
         rc, out, err = common.execute('docker ps', log_stdout=False)
         if rc != 0:
             raise Exception("Docker is not running - see manual.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,8 @@ def _print_config():
     logger.info(f"# ROOKCHECK_NODE_IMAGE_USER={settings.NODE_IMAGE_USER}")
     logger.info(f"# ROOKCHECK__USE_THREADS={settings._USE_THREADS}")
     logger.info(f"# ROOKCHECK__REMOVE_WORKSPACE={settings._REMOVE_WORKSPACE}")
+    logger.info(
+        f"# ROOKCHECK__TEAR_DOWN_CLUSTER={settings._TEAR_DOWN_CLUSTER}")
     logger.info(f"# ROOKCHECK_HARDWARE_PROVIDER={settings.HARDWARE_PROVIDER}")
     logger.info("# Hardware provider specific config:")
     logger.info("# ----------------------------------")

--- a/tests/lib/hardware/aws_ec2.py
+++ b/tests/lib/hardware/aws_ec2.py
@@ -315,14 +315,24 @@ class Hardware(HardwareBase):
         for t in threads:
             t.join()
 
-    def destroy(self):
-        node_instances = []
-        logger.info("Remove all nodes from Hardware")
-        for n in list(self.nodes):
-            node_instances.append(self.nodes[n]._instance)
-            # FIXME(jhesketh): This waits until the node is terminated and
-            #                  therefore is quite slow. We should thread this.
-            self.node_remove(self.nodes[n])
+    def destroy(self, skip=False):
+        super().destroy(skip=skip)
+
+        if skip:
+            if self._keypair:
+                logger.warning(f"Leaving keypair {self._keypair}")
+            if self._security_group:
+                logger.warning(
+                    f"Leaving security group {self._security_group}")
+            if self._subnet:
+                logger.warning(f"Leaving subnet {self._subnet}")
+            if self._routetable:
+                logger.warning(f"Leaving routetable {self._routetable}")
+            if self._gateway:
+                logger.warning(f"Leaving gateway {self._gateway}")
+            if self._vpc:
+                logger.warning(f"Leaving VPC {self._vpc}")
+            return
 
         self._keypair.delete()
         logger.info(f"Deleted keypair {self._keypair}")
@@ -338,9 +348,3 @@ class Hardware(HardwareBase):
         logger.info(f"Deleted gateway {self._gateway}")
         self._vpc.delete()
         logger.info(f"Deleted vpc {self._vpc}")
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type, value, traceback):
-        self.destroy()

--- a/tests/lib/hardware/libvirt.py
+++ b/tests/lib/hardware/libvirt.py
@@ -429,7 +429,12 @@ class Hardware(HardwareBase):
         for t in threads:
             t.join()
 
-    def destroy(self):
-        super().destroy()
+    def destroy(self, skip=False):
+        super().destroy(skip=skip)
+
+        if skip:
+            logger.warning(f"Leaving network {self._network.name()}")
+            return
+
         self._network.destroy()
         logger.info(f"network {self._network.name()} destroyed")

--- a/tests/lib/hardware/openstack_sdk.py
+++ b/tests/lib/hardware/openstack_sdk.py
@@ -226,8 +226,23 @@ class Hardware(HardwareBase):
         for t in threads:
             t.join()
 
-    def destroy(self):
-        super().destroy()
+    def destroy(self, skip=False):
+        super().destroy(skip=skip)
+
+        if skip:
+            if self._router_private:
+                logger.warning(f"Leaving router {self._router_private.name}")
+            if self._subnet_private:
+                logger.warning(f"Leaving subnet {self._subnet_private.name}")
+            if self._network_private:
+                logger.warning(f"Leaving network {self._network_private.name}")
+            if self._security_group:
+                logger.warning(
+                    f"Leaving security group {self._security_group.name}")
+            if self._keypair:
+                logger.warning(f"Leaving keypair {self._keypair.name}")
+            return
+
         self._delete_network_private()
         self._delete_security_group()
         self._delete_keypair()

--- a/tests/lib/kubernetes/kubernetes_base.py
+++ b/tests/lib/kubernetes/kubernetes_base.py
@@ -26,6 +26,7 @@ import re
 import time
 from typing import List
 
+from tests.config import settings
 from tests.lib import common
 from tests.lib.hardware.hardware_base import HardwareBase
 from tests.lib.hardware.node_base import NodeBase
@@ -85,7 +86,7 @@ class KubernetesBase(ABC):
         return self
 
     def __exit__(self, type, value, traceback):
-        self.destroy()
+        self.destroy(skip=not settings.as_bool('_TEAR_DOWN_CLUSTER'))
 
     def _configure_kubernetes_client(self):
         kubernetes.config.load_kube_config(self.kubeconfig)
@@ -157,12 +158,12 @@ class KubernetesBase(ABC):
         )
 
     def destroy(self, skip=True):
-        logger.info(f"kube destroy on hardware {self.hardware}")
         if skip:
             # We can skip in most cases since the nodes themselves will be
             # destroyed instead.
             return
         # TODO(jhesketh): Uninstall kubernetes
+        logger.info(f"kube destroy on hardware {self.hardware}")
         pass
 
     def configure_kubernetes_client(self):

--- a/tests/lib/rook/base.py
+++ b/tests/lib/rook/base.py
@@ -17,6 +17,7 @@ import os
 import time
 import re
 
+from tests.config import settings
 from tests.lib import common
 from abc import ABC, abstractmethod
 
@@ -46,12 +47,12 @@ class RookBase(ABC):
         pass
 
     def destroy(self, skip=True):
-        logger.info(f"rook destroy on {self.kubernetes.hardware}")
         if skip:
             # We can skip in most cases since the kubernetes cluster, if not
             # the nodes themselves will be destroyed instead.
             return
         # TODO(jhesketh): Uninstall rook
+        logger.info(f"rook destroy on {self.kubernetes.hardware}")
         pass
 
     def execute_in_ceph_toolbox(self, command, log_stdout=False):
@@ -147,4 +148,4 @@ class RookBase(ABC):
         return self
 
     def __exit__(self, type, value, traceback):
-        self.destroy()
+        self.destroy(skip=not settings.as_bool('_TEAR_DOWN_CLUSTER'))

--- a/tests/lib/workspace.py
+++ b/tests/lib/workspace.py
@@ -182,13 +182,18 @@ class Workspace():
         os.makedirs(os.path.join(working_dir_path, 'bin'))
         return working_dir_path
 
-    def destroy(self):
+    def destroy(self, skip=False):
         # This kills the SSH_AGENT_PID agent
         try:
             self.execute('ssh-agent -k', check=True)
         except subprocess.CalledProcessError:
             logger.warning(f'Killing ssh-agent with PID'
                            f' {self._ssh_agent_pid} failed')
+
+        if skip:
+            logger.warning("The workspace directory will not be removed!")
+            logger.warning(f"Workspace left behind at {self.working_dir}")
+            return
 
         if settings.as_bool('_REMOVE_WORKSPACE'):
             logger.info(f"Removing workspace {self.working_dir} from disk")
@@ -225,4 +230,4 @@ class Workspace():
         return self
 
     def __exit__(self, type, value, traceback):
-        self.destroy()
+        self.destroy(skip=not settings.as_bool('_TEAR_DOWN_CLUSTER'))


### PR DESCRIPTION
Add option to leave cluster available after run

By default the cluster is destroyed at each run. This adds a new option
(_tear_down_cluster) which can be set to False to keep the cluster around.

This also tidies up the removal of AWS nodes which can use the super
class's method to destroy them instead of repeating the code.

