### PR TITLE
rook/base: Reduce ROOK_DISCOVER_DEVICES_INTERVAL to 2m

### DIFF
--- a/tests/lib/rook/base.py
+++ b/tests/lib/rook/base.py
@@ -80,6 +80,11 @@ class RookBase(ABC):
             "--namespace rook-ceph set env "
             "deployment/rook-ceph-operator ROOK_LOG_LEVEL=DEBUG")
 
+        # reduce wait time to discover devices
+        self.kubernetes.kubectl(
+            "--namespace rook-ceph set env "
+            "deployment/rook-ceph-operator ROOK_DISCOVER_DEVICES_INTERVAL=2m")
+
         logger.info("Wait for rook-ceph-operator running")
         pattern = re.compile(r'.*rook-ceph-operator.*Running')
         common.wait_for_result(


### PR DESCRIPTION
This will speedup the discovery of new devices.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>