### PR TITLE
Improve TEAR_DOWN_CLUSTER_CONFIRM handling

### DIFF
--- a/tests/lib/common.py
+++ b/tests/lib/common.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+import pdb
 import subprocess
 import threading
 import time
@@ -173,3 +174,15 @@ def execute(command: str, capture: bool = False, check: bool = True,
             raise subprocess.CalledProcessError(rc, command)
 
     return (rc, output['stdout'], output['stderr'])
+
+
+def handle_cleanup_input(msg):
+    msg = f"\n{msg} (c=continue, d=debugger)\n"
+    # TODO: you need to press enter after the letter
+    while True:
+        i = input(msg).lower()
+        if i == "c":
+            break
+        elif i == "d":
+            pdb.set_trace()
+            break

--- a/tests/lib/hardware/hardware_base.py
+++ b/tests/lib/hardware/hardware_base.py
@@ -29,6 +29,7 @@ from typing import Dict, List
 import threading
 
 from tests.config import settings
+from tests.lib.common import handle_cleanup_input
 from tests.lib.hardware.node_base import NodeBase, NodeRole
 from tests.lib.workspace import Workspace
 
@@ -98,7 +99,7 @@ class HardwareBase(ABC):
             return
 
         if settings.as_bool('_TEAR_DOWN_CLUSTER_CONFIRM'):
-            input("press any key to cleanup hardware")
+            handle_cleanup_input("pause before cleanup hardware")
 
         logger.info("Remove all nodes from Hardware")
         for n in list(self.nodes):

--- a/tests/lib/kubernetes/kubernetes_base.py
+++ b/tests/lib/kubernetes/kubernetes_base.py
@@ -164,7 +164,7 @@ class KubernetesBase(ABC):
             return
 
         if settings.as_bool('_TEAR_DOWN_CLUSTER_CONFIRM'):
-            input("press any key to cleanup kubernetes")
+            common.handle_cleanup_input("pause before cleanup kubernetes")
 
         # TODO(jhesketh): Uninstall kubernetes
         logger.info(f"kube destroy on hardware {self.hardware}")

--- a/tests/lib/rook/base.py
+++ b/tests/lib/rook/base.py
@@ -52,7 +52,7 @@ class RookBase(ABC):
             return
 
         if settings.as_bool('_TEAR_DOWN_CLUSTER_CONFIRM'):
-            input("press any key to cleanup rook")
+            common.handle_cleanup_input("pause before cleanup rook")
 
         # TODO(jhesketh): Uninstall rook
         logger.info(f"rook destroy on {self.kubernetes.hardware}")

--- a/tests/lib/workspace.py
+++ b/tests/lib/workspace.py
@@ -24,7 +24,7 @@ import uuid
 import paramiko.rsakey
 
 from tests.config import settings
-from tests.lib.common import execute
+from tests.lib.common import execute, handle_cleanup_input
 
 
 logger = logging.getLogger(__name__)
@@ -184,7 +184,7 @@ class Workspace():
 
     def destroy(self, skip=False):
         if settings.as_bool('_TEAR_DOWN_CLUSTER_CONFIRM'):
-            input("press any key to cleanup workspace")
+            handle_cleanup_input("pause before cleanup workspace")
 
         # This kills the SSH_AGENT_PID agent
         try:


### PR DESCRIPTION
Add the possibility to go into the python debugger (pdb) to be able to
look further into the problem.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>