### PR TITLE
Sync time using NTP immediate command

### DIFF
--- a/tests/assets/ansible/roles/node_base/tasks/sles-15.yml
+++ b/tests/assets/ansible/roles/node_base/tasks/sles-15.yml
@@ -51,10 +51,7 @@
       - chrony
     state: present
 
-- name: Ensure system is NTP time synced  # noqa 301
-  command: chronyc waitsync
-
-- name: Apply NTP update  # noqa 301
+- name: Sync NTP immediately # noqa 301
   command: chronyc makestep
 
 # kernel-default-base is not enough (eg. skuba needs vxlan which is not in the base kernel currently (see bsc#1171903)


### PR DESCRIPTION
Using waitsync is necessary on an existing machine to avoid
disrupting services by a too quick adjustment.
In the CI contexty of setting up new machines, this is a waste of
time (as much as 150s just for chronyc waitsync)