### PR TITLE
Use -n instead of --namespace for kubectl

### DIFF
--- a/tests/lib/kubernetes/kubernetes_base.py
+++ b/tests/lib/kubernetes/kubernetes_base.py
@@ -145,7 +145,7 @@ class KubernetesBase(ABC):
                 with open(os.path.join(pod_logs_dest_dir,
                                        f'describe_{pod_name}.txt'), 'w') as f:
                     rc, stdout, stderr = self.kubectl(
-                        f"--namespace {namespace} describe pod {pod_name}",
+                        f"-n {namespace} describe pod {pod_name}",
                         log_stdout=False)
                     f.write(stdout)
             except Exception:
@@ -193,7 +193,7 @@ class KubernetesBase(ABC):
     def execute_in_pod(self, command, pod, namespace="rook-ceph",
                        log_stdout=True, log_stderr=True):
         return self.kubectl(
-            '--namespace %s exec -t "%s" -- bash -c "$(cat <<\'EOF\'\n'
+            '-n %s exec -t "%s" -- bash -c "$(cat <<\'EOF\'\n'
             '%s'
             '\nEOF\n)"'
             % (namespace, pod, command),
@@ -203,7 +203,7 @@ class KubernetesBase(ABC):
 
     def get_pods_by_app_label(self, label, namespace="rook-ceph"):
         pods_string = self.kubectl(
-            '--namespace %s get pod -l app="%s"'
+            '-n %s get pod -l app="%s"'
             ' --output custom-columns=name:metadata.name --no-headers'
             % (namespace, label)
         )[1].strip()
@@ -211,7 +211,7 @@ class KubernetesBase(ABC):
 
     def get_services_by_app_label(self, label, namespace="rook-ceph"):
         services_string = self.kubectl(
-            '--namespace %s get svc -l app="%s"'
+            '-n %s get svc -l app="%s"'
             ' --output custom-columns=name:metadata.name --no-headers'
             % (namespace, label)
         )[1].strip()
@@ -264,6 +264,6 @@ class KubernetesBase(ABC):
         pattern = re.compile(r'.*Running')
         common.wait_for_result(
             self.kubectl,
-            f'--namespace {namespace} get pod -l app="{label}" --no-headers',
+            f'-n {namespace} get pod -l app="{label}" --no-headers',
             matcher=common.regex_count_matcher(pattern, count),
             attempts=attempts, interval=sleep)

--- a/tests/lib/rook/base.py
+++ b/tests/lib/rook/base.py
@@ -77,18 +77,18 @@ class RookBase(ABC):
 
         # set operator log level
         self.kubernetes.kubectl(
-            "--namespace rook-ceph set env "
+            "-n rook-ceph set env "
             "deployment/rook-ceph-operator ROOK_LOG_LEVEL=DEBUG")
 
         # reduce wait time to discover devices
         self.kubernetes.kubectl(
-            "--namespace rook-ceph set env "
+            "-n rook-ceph set env "
             "deployment/rook-ceph-operator ROOK_DISCOVER_DEVICES_INTERVAL=2m")
 
         logger.info("Wait for rook-ceph-operator running")
         pattern = re.compile(r'.*rook-ceph-operator.*Running')
         common.wait_for_result(
-            self.kubernetes.kubectl, "--namespace rook-ceph get pods",
+            self.kubernetes.kubectl, "-n rook-ceph get pods",
             matcher=common.regex_count_matcher(pattern, 1),
             attempts=30, interval=10)
 
@@ -101,7 +101,7 @@ class RookBase(ABC):
                     "(this may take a while...)")
         pattern = re.compile(r'.*rook-ceph-osd-prepare.*Completed')
         common.wait_for_result(
-            self.kubernetes.kubectl, "--namespace rook-ceph get pods"
+            self.kubernetes.kubectl, "-n rook-ceph get pods"
             " -l app=rook-ceph-osd-prepare",
             matcher=common.regex_count_matcher(pattern, 3),
             attempts=120, interval=15)
@@ -109,7 +109,7 @@ class RookBase(ABC):
         logger.info("Wait for rook-ceph-tools running")
         pattern = re.compile(r'.*rook-ceph-tools.*Running')
         common.wait_for_result(
-            self.kubernetes.kubectl, "--namespace rook-ceph get pods",
+            self.kubernetes.kubectl, "-n rook-ceph get pods",
             matcher=common.regex_count_matcher(pattern, 1),
             attempts=30, interval=10)
 
@@ -134,7 +134,7 @@ class RookBase(ABC):
         logger.info("Wait for 2 mdses to start")
         pattern = re.compile(r'.*rook-ceph-mds-myfs.*Running')
         common.wait_for_result(
-            self.kubernetes.kubectl, "--namespace rook-ceph get pods",
+            self.kubernetes.kubectl, "-n rook-ceph get pods",
             log_stdout=False,
             matcher=common.regex_count_matcher(pattern, 2),
             attempts=60, interval=5)


### PR DESCRIPTION
That way, the logs show more from the real command without wasting
space for the --namespace argument.

Eg.

07:06:41 kubectl --namespace rook-ceph get pod -l app=

will then show more.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>