### PR TITLE
tests/test_basic: Wait longer for OSD in test_add_node

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -215,7 +215,7 @@ def test_add_node(rook_cluster):
 
     i = 0
     while osds != workers_new:
-        if i == 90:
+        if i == 200:
             pytest.fail("rook did not add an additional osd-node")
             break
         time.sleep(10)


### PR DESCRIPTION
Let's see if this will fix the problem.

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>