### PR TITLE
hardware/libvirt: add lock for libvirt defineXML

### DIFF
--- a/tests/lib/hardware/libvirt.py
+++ b/tests/lib/hardware/libvirt.py
@@ -46,6 +46,9 @@ from tests.lib.workspace import Workspace
 
 logger = logging.getLogger(__name__)
 
+# this lock needs to resolve race condition issue while defining a node
+libvirt_define_node_lock = threading.Lock()
+
 
 class Node(NodeBase):
     def __init__(self, name, role, tags, conn, image_path,
@@ -72,7 +75,16 @@ class Node(NodeBase):
         logger.info(f"node {self.name}: booting with "
                     f"image {self._snap_img_path}")
         logger.debug(f"node {self.name}: libvirt xml: {xml}")
-        self._dom = self._conn.defineXML(xml)
+        try:
+            libvirt_define_node_lock.acquire()
+            self._dom = self._conn.defineXML(xml)
+        except libvirt.libvirtError as e:
+            logger.error(
+                f"unable to define node '{self.name}' using xml: {xml}")
+            raise e
+        finally:
+            libvirt_define_node_lock.release()
+
         self._dom.create()
         if self._role == NodeRole.WORKER:
             for i in range(0, settings.WORKER_INITIAL_DATA_DISKS):

--- a/tests/lib/hardware/libvirt.py
+++ b/tests/lib/hardware/libvirt.py
@@ -329,7 +329,7 @@ class Hardware(HardwareBase):
     def _get_image_path(self):
         if (settings.LIBVIRT.IMAGE.startswith("http://") or
                 settings.LIBVIRT.IMAGE.startswith("https://")):
-            logging.debug(
+            logging.info(
                 f"Downloading image from {settings.LIBVIRT.IMAGE}")
             download_location = os.path.join(
                 self.workspace.working_dir,


### PR DESCRIPTION
On some version of libvirt the "Duplicate key" internal error occurs
while trying to define a node in parallel, for example:

    Traceback (most recent call last):
      File "/usr/lib64/python3.6/threading.py", line 916, in _bootstrap_inner
        self.run()
      File "/usr/lib64/python3.6/threading.py", line 864, in run
        self._target(*self._args, **self._kwargs)
      File "/home/kyr/suse/rookcheck/tests/lib/hardware/libvirt.py", line 400, in _boot_node
        node = self.node_create(name, role, tags)
      File "/home/kyr/suse/rookcheck/tests/lib/hardware/libvirt.py", line 396, in node_create
        node.boot()
      File "/home/kyr/suse/rookcheck/tests/lib/hardware/libvirt.py", line 75, in boot
        self._dom = self._conn.defineXML(xml)
      File "/home/kyr/suse/rookcheck/.tox/py36/lib64/python3.6/site-packages/libvirt.py", line 4049, in defineXML
        if ret is None:raise libvirtError('virDomainDefineXML() failed', conn=self)
    libvirt.libvirtError: internal error: Duplicate key

This patch adds a workaround for it.

Fixes: https://github.com/SUSE/rookcheck/issues/161

Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@suse.com>