### PR TITLE
hardware_base: Decouple ANSIBLE_EXTRA_VARS settings

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -51,6 +51,7 @@ _gather_logs_dir = ""
 # removed from the disk.
 _remove_workspace = true
 
-# Allow passing extra variables to Ansible (below as JSON)
-# example: export ROOKCHECK_ANSIBLE_EXTRA_VARS='{"extra_repos":{"storage_latest": "http://myextra.repo/"}}'
+# Allow passing extra variables to Ansible. This can be in any format
+# that ansible-playbook accepts for the --extra-vars parameter
+# See https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#defining-variables-at-runtime  # noqa
 ansible_extra_vars = ""

--- a/tests/lib/hardware/hardware_base.py
+++ b/tests/lib/hardware/hardware_base.py
@@ -151,13 +151,12 @@ class HardwareBase(ABC):
         else:
             limit = ""
 
-        # Supplied extra_vars from settings always take precedence
-        if settings.ANSIBLE_EXTRA_VARS:
-            extra_vars.update(json.loads(settings.ANSIBLE_EXTRA_VARS))
+        extra_vars_param = ""
         if extra_vars:
-            extra_vars_param = f"--extra-vars '{json.dumps(extra_vars)}'"
-        else:
-            extra_vars_param = ""
+            extra_vars_param += f" --extra-vars '{json.dumps(extra_vars)}'"
+        if settings.ANSIBLE_EXTRA_VARS:
+            extra_vars_param += " --extra-vars "
+            f"'{settings.ANSIBLE_EXTRA_VARS}'"
 
         logger.info(f'Running playbook {path} ({limit})')
         self.workspace.execute(


### PR DESCRIPTION
Instead of merging settings.ANSIBLE_EXTRA_VARS with the variable
"extra_vars" provided by ansible_run_playbook(), decouple both
variables. That way, extra_vars (the method parameter) can be set from
the code (eg. the SES rook code) and settings.ANSIBLE_EXTRA_VARS can
be set by the user and it can be something independent (eg. a file
@foo.yaml).

Signed-off-by: Thomas Bechtold <tbechtold@suse.com>