### PR TITLE
Restore support for loading .env files

### DIFF
--- a/tests/config.py
+++ b/tests/config.py
@@ -24,6 +24,7 @@ settings_dir = os.path.realpath(os.path.join(
 
 settings = Dynaconf(
     envvar_prefix='ROOKCHECK',
+    load_dotenv=True,
     settings_files=[
         os.path.join(settings_dir, 'settings.toml'),
         os.path.join(settings_dir, 'openstack.toml'),


### PR DESCRIPTION
Since moving to Dynaconf v3 we lost automatic loading of .env files.
https://www.dynaconf.com/release_notes/#load-of-dotenv-env-is-now-disabled-by-default