### PR TITLE
Fix passing ANSIBLE_EXTRA_VARS

### DIFF
--- a/tests/lib/hardware/hardware_base.py
+++ b/tests/lib/hardware/hardware_base.py
@@ -155,8 +155,8 @@ class HardwareBase(ABC):
         if extra_vars:
             extra_vars_param += f" --extra-vars '{json.dumps(extra_vars)}'"
         if settings.ANSIBLE_EXTRA_VARS:
-            extra_vars_param += " --extra-vars "
-            f"'{settings.ANSIBLE_EXTRA_VARS}'"
+            extra_vars_param += f" --extra-vars "\
+                                f" '{settings.ANSIBLE_EXTRA_VARS}'"
 
         logger.info(f'Running playbook {path} ({limit})')
         self.workspace.execute(


### PR DESCRIPTION
This PR fixes a concatenation issue ending up in having
--extra-vars to be empty.
Looks like the += syntax with "f" strings needs an explicit
multiline indication to concatenate properly.