### PR TITLE
Bump general timeouts due to slow ECP

### DIFF
--- a/config/openstack.toml
+++ b/config/openstack.toml
@@ -1,8 +1,7 @@
 [openstack]
 
 # The node image by either ID or NAME
-# os_node_image = "openSUSE-Leap-15.2-JeOS.x86_64-OpenStack-Cloud"
-node_image = "b73a273d-6e63-43f2-8e73-defe0da54fd6"
+node_image = "openSUSE-Leap-15.2-JeOS-OpenStack-Cloud-Build31.149"
 
 # The node size or flavour name as known by the provider
 node_size = "m1.medium"

--- a/tests/lib/rook/base.py
+++ b/tests/lib/rook/base.py
@@ -81,22 +81,15 @@ class RookBase(ABC):
         self.kubernetes.kubectl("create namespace rook-ceph")
         self._install_operator()
 
-        self.kubernetes.kubectl_apply(
-            os.path.join(self.ceph_dir, 'cluster.yaml'))
-        self.kubernetes.kubectl_apply(
-            os.path.join(self.ceph_dir, 'toolbox.yaml'))
-
         # reduce wait time to discover devices
         self.kubernetes.kubectl(
             "-n rook-ceph set env "
             "deployment/rook-ceph-operator ROOK_DISCOVER_DEVICES_INTERVAL=2m")
 
-        logger.info("Wait for rook-ceph-operator running")
-        pattern = re.compile(r'.*rook-ceph-operator.*Running')
-        common.wait_for_result(
-            self.kubernetes.kubectl, "-n rook-ceph get pods",
-            matcher=common.regex_count_matcher(pattern, 1),
-            attempts=30, interval=10)
+        self.kubernetes.kubectl_apply(
+            os.path.join(self.ceph_dir, 'cluster.yaml'))
+        self.kubernetes.kubectl_apply(
+            os.path.join(self.ceph_dir, 'toolbox.yaml'))
 
         logger.info("Wait for OSD prepare to complete "
                     "(this may take a while...)")
@@ -133,6 +126,13 @@ class RookBase(ABC):
         else:
             logger.info('Deploying rook operator - using kubectl apply ...')
             self._install_operator_kubectl()
+
+        logger.info("Wait for rook-ceph-operator running")
+        pattern = re.compile(r'.*rook-ceph-operator.*Running')
+        common.wait_for_result(
+            self.kubernetes.kubectl, "-n rook-ceph get pods",
+            matcher=common.regex_count_matcher(pattern, 1),
+            attempts=30, interval=10)
 
         # set operator log level
         self.kubernetes.kubectl(

--- a/tests/lib/rook/base.py
+++ b/tests/lib/rook/base.py
@@ -161,7 +161,7 @@ class RookBase(ABC):
             self.kubernetes.kubectl, "-n rook-ceph get pods",
             log_stdout=False,
             matcher=common.regex_count_matcher(pattern, 2),
-            attempts=60, interval=5)
+            attempts=120, interval=10)
 
         logger.info("Wait for myfs to be active")
         pattern = re.compile(r'.*active')
@@ -169,7 +169,7 @@ class RookBase(ABC):
             self.execute_in_ceph_toolbox, "ceph fs status myfs",
             log_stdout=False,
             matcher=common.regex_matcher(pattern),
-            attempts=60, interval=5)
+            attempts=120, interval=10)
         logger.info("Ceph FS successfully installed and ready!")
 
     def get_number_of_osds(self):

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -203,7 +203,7 @@ def test_add_storage(rook_cluster):
     # this may take a while
     i = 0
     while osds < osds_expected:
-        if i == 60:
+        if i == 120:
             pytest.fail("rook was not able to add {new_osds} of required osds")
             break
         time.sleep(10)
@@ -279,7 +279,7 @@ def test_rbd_pvc(rook_cluster):
     pattern = re.compile(r'.*rook-ceph-block*')
     common.wait_for_result(rook_cluster.kubernetes.kubectl, "get sc",
                            matcher=common.regex_matcher(pattern),
-                           attempts=10, interval=6)
+                           attempts=30, interval=10)
 
     # create an rbd based PVC
     output = rook_cluster.kubernetes.kubectl_apply(
@@ -291,7 +291,7 @@ def test_rbd_pvc(rook_cluster):
     pattern = re.compile(r'.*Bound*')
     common.wait_for_result(rook_cluster.kubernetes.kubectl, "get pvc rbd-pvc",
                            matcher=common.regex_matcher(pattern),
-                           attempts=10, interval=6)
+                           attempts=30, interval=10)
 
     # create a pod using the PVC
     output = rook_cluster.kubernetes.kubectl_apply(
@@ -304,7 +304,7 @@ def test_rbd_pvc(rook_cluster):
     common.wait_for_result(rook_cluster.kubernetes.kubectl,
                            "get pod csirbd-demo-pod",
                            matcher=common.regex_matcher(pattern),
-                           attempts=10, interval=10)
+                           attempts=30, interval=10)
 
     rook_cluster.kubernetes.kubectl('delete pod csirbd-demo-pod')
     rook_cluster.kubernetes.kubectl('delete pvc rbd-pvc')


### PR DESCRIPTION
The tests were previously passing because we weren't correctly
failing once a timeout reached. Now that we are failing we are hitting
these timeouts. So bump them for now.

(Also fix up a default in a config file)