### PR TITLE
Allow substitutions to helm values

### DIFF
--- a/config/ses.toml
+++ b/config/ses.toml
@@ -8,7 +8,11 @@ target = "devel7"
   [ses.ses7]
     rook_ceph_chart = "registry.suse.de/suse/sle-15-sp2/update/products/ses7/charts/rook-ceph:latest"
     [ses.ses7.yaml_substitutions]
-      # "suse.com" = "suse.de/devel/storage/7.0/containers"
+      # "registry.suse.com" = "registry.suse.de/devel/storage/7.0/containers"
+
+    [ses.ses7.helm_values_substitutions]
+      # We can't predict the pinned versions of containers, so instead of
+      # supplying extra values.yaml files we perform substitutions
 
     [ses.ses7.repositories]
       # Each key/value under this sub-heading is a repository
@@ -21,6 +25,18 @@ target = "devel7"
     [ses.devel7.yaml_substitutions]
       "registry.suse.com" = "registry.suse.de/devel/storage/7.0/containers"
       "# ROOK_CSI_" = "ROOK_CSI_"
+
+    [ses.devel7.helm_values_substitutions]
+      # We can't predict the pinned versions of containers, so instead of
+      # supplying extra values.yaml files we perform substitutions
+      "registry.suse.com" = "registry.suse.de/devel/storage/7.0/containers"
+      "#image: registry" = "image: registry"
+      "#cephcsi:" = "cephcsi:"
+      "#registrar:" = "registrar:"
+      "#provisioner:" = "provisioner:"
+      "#snapshotter:" = "snapshotter:"
+      "#attacher:" = "attacher:"
+      "#resizer:" = "resizer:"
 
     [ses.devel7.repositories]
       # Each key/value under this sub-heading is a repository

--- a/tests/lib/rook/ses.py
+++ b/tests/lib/rook/ses.py
@@ -27,7 +27,9 @@ class RookSes(RookBase):
     def __init__(self, workspace, kubernetes):
         super().__init__(workspace, kubernetes)
         self.ceph_dir = os.path.join(
-            self.workspace.working_dir, 'rook', 'ceph')
+            self.workspace.working_dir, 'rook/ceph')
+        self.helm_dir = os.path.join(
+            self.workspace.working_dir, 'helm/rook-ceph')
         self.rook_chart = settings(
             f"SES.{settings.SES.TARGET}.rook_ceph_chart")
 
@@ -45,6 +47,7 @@ class RookSes(RookBase):
             'playbook_rook_ses.yaml', extra_vars=repo_vars)
         self._get_rook()
         self._fix_yaml()
+        self._fix_chart_values()
 
     def _get_rook(self):
         # TODO (bleon)
@@ -61,6 +64,13 @@ class RookSes(RookBase):
         replacements = settings(
             f'SES.{settings.SES.TARGET}.yaml_substitutions')
         recursive_replace(self.ceph_dir, replacements)
+
+    def _fix_chart_values(self):
+        # Replacements are to point container paths and/or versions to the
+        # expected ones to test.
+        replacements = settings(
+            f'SES.{settings.SES.TARGET}.helm_values_substitutions')
+        recursive_replace(self.helm_dir, replacements)
 
     def _get_charts(self):
         super()._get_charts()


### PR DESCRIPTION
This allows us to overwrite helm values using a very simple search
+ replace.

We can't trivially provide a second values.yaml as we don't know the
exact container version numbers.

This should allow us to test SES builds from IBS.