### PR TITLE
Skip pulling chart

### DIFF
--- a/tests/lib/rook/ses.py
+++ b/tests/lib/rook/ses.py
@@ -82,7 +82,7 @@ class RookSes(RookBase):
     def _get_charts(self):
         super()._get_charts()
         logger.info(f"Grabbing chart {self.rook_chart}")
-        self.kubernetes.helm(f"chart pull {self.rook_chart}")
+        # self.kubernetes.helm(f"chart pull {self.rook_chart}")
         self.kubernetes.helm(f"chart export {self.rook_chart}"
                              f" -d {self.workspace.helm_dir}")
 


### PR DESCRIPTION
We only need to export the chart. If we pull the new format the export
step doesn't work due to the chart not being in the expected targz.

Signed-off-by: Joshua Hesketh <jhesketh@suse.com>