### PR TITLE
Use devel-containers instead of the upstream ones

### DIFF
--- a/config/ses.toml
+++ b/config/ses.toml
@@ -45,6 +45,8 @@ target = "cr_ses71"
       "#snapshotter:" = "snapshotter:"
       "#attacher:" = "attacher:"
       "#resizer:" = "resizer:"
+      "#  image: registry.k8s.io/sig-storage" = "  image: registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/cephcsi"
+      "#  image: registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/cephcsi/cephcsi" = "  image: registry.suse.de/devel/storage/7.0/pacific/containers/ses/7.1/cephcsi/cephcsi"
 
     [ses.devel71.repositories]
       # Each key/value under this sub-heading is a repository


### PR DESCRIPTION
For our development env we should also ensure to use our dev-containers instead the ones from upstream.

Signed-off-by: Stefan Haas <shaas@suse.com>