### PR TITLE
raise error when unable to query the latest helm version

### DIFF
--- a/tests/lib/rook/base.py
+++ b/tests/lib/rook/base.py
@@ -81,7 +81,9 @@ class RookBase(ABC):
 
     def _get_helm(self):
         url = "https://api.github.com/repos/helm/helm/releases/latest"
-        version = requests.get(url).json()["tag_name"]
+        r = requests.get(url)
+        r.raise_for_status()
+        version = r.json()["tag_name"]
         version = "v3.9.0-rc.1"
         self.workspace.get_unpack(
             "https://get.helm.sh/helm-%s-linux-amd64.tar.gz" % version)

--- a/tests/lib/rook/base.py
+++ b/tests/lib/rook/base.py
@@ -84,7 +84,6 @@ class RookBase(ABC):
         r = requests.get(url)
         r.raise_for_status()
         version = r.json()["tag_name"]
-        version = "v3.9.0-rc.1"
         self.workspace.get_unpack(
             "https://get.helm.sh/helm-%s-linux-amd64.tar.gz" % version)
         os.rename(os.path.join(self.workspace.tmp_dir, 'linux-amd64', 'helm'),


### PR DESCRIPTION
raise an error if the http get request fails to query `api.github.com`
for the latest helm version

also use the latest helm feature release (v3.11.0) rather than hard-coding the the prior pre-release (v3.9.0-rc.1)

Signed-off-by: Michael Fritch <mfritch@suse.com>